### PR TITLE
Phase 7: Integrations — Stripe 8→22, Nodemailer 6→9, Mailchimp superagent→fetch

### DIFF
--- a/docs/dependency-upgrade-plan.md
+++ b/docs/dependency-upgrade-plan.md
@@ -186,20 +186,33 @@ live smoke (login, `/books`, `/reviewers`) after each. One commit per major for 
 - [x] `npm audit` dropped from the Phase 0 baseline of 48 to **19** after removing jade's
   transitive tree and upgrading Express (full audit reconciliation tracked in Phase 8).
 
-## Phase 7 — Integrations (Stripe, Nodemailer, Mailchimp)
+## Phase 7 — Integrations (Stripe, Nodemailer, Mailchimp) ✅ (completed 2026-06-21)
 
-- [ ] `stripe` 8 → 22 — **largest API jump**. Pin an `apiVersion` when constructing the client:
-  `require('stripe')(key, { apiVersion: '2025-...' })`. Re-verify
-  `paymentIntents.create({ amount, currency, payment_method, confirm: true })` in
-  `routes/paymentCheckout.js` against the current API (the `confirm`/`payment_method` flow and
-  error shapes changed across versions). Test with Stripe test keys.
-- [ ] `nodemailer` 6 → 9 — `createTransport` config and the template-send flow in
-  `lib/email.js` are broadly compatible; verify SMTP auth options and run a real send to a
-  test inbox. Note: the HTML templates in `lib/email.js` start with a stray `` ;`` after the
-  backtick — clean up while here.
-- [ ] Mailchimp call in `routes/login.js`: now that `superagent` is explicit (Phase 0),
-  either keep it pinned or replace with Node's built-in `fetch`. Verify the
-  `Authorization: Basic` header and member-status sync still work.
+Three independent sub-phases, one commit each.
+
+- [x] **`stripe` 8 → 22** (22.3.1). Pinned `apiVersion: '2026-06-24.dahlia'` (the version the
+  v22 SDK targets) so an SDK bump never silently changes behavior via the account default.
+  **Breaking change confirmed & fixed:** under the pinned API, `paymentIntents.create` with a
+  bare `confirm: true` errors (`"...you must provide a return_url"`) because the account has
+  dashboard-enabled redirect-capable methods. Added
+  `automatic_payment_methods: { enabled: true, allow_redirects: 'never' }` — verified live
+  against **Stripe test mode** (`pm_card_visa` → status `succeeded`). Updated the
+  `paymentCheckout` test to assert the new option.
+- [x] **`nodemailer` 6 → 9** (9.0.3). `createTransport`/`sendMail` API unchanged; **SMTP auth
+  verified live** via `transporter.verify()` (no outbound send). Fixed a long-standing bug:
+  every HTML template opened with `` `; `` (backtick + literal semicolon), so each email body
+  started with a stray `;` — removed from all four templates in `lib/email.js`.
+- [x] **Mailchimp: `superagent` → native `fetch`** across all four callers (`login.js`,
+  `suscribeAuthor.js`, `deleteUser.js`, `registerReviewer.js`); removed the deprecated
+  `superagent` dependency (Node 22 ships a global `fetch`). Preserved the Basic-auth header,
+  JSON bodies, and the "treat 400 as success" semantics. **Read path verified live** against
+  both real lists (GET → 200; 94 writers / 502 readers). Robustness gains: the login status
+  sync can no longer abort login on a Mailchimp outage (guarded on `response.ok`, so a numeric
+  error `status` is never persisted); `deleteUser`/`suscribeAuthor` fetches now live inside the
+  existing try/catch (no detached `.end()` callbacks); dropped a stray debug `console.log` in
+  `registerReviewer`. **Pre-existing bug left for a later pass:** `deleteUser` still reports
+  "usuario borrado" without deleting when the Mailchimp unsubscribe fails.
+- [x] `npm test` 18/18 green; live server boot + `/`, `/books`, `/reviewers` all 200.
 
 ## Phase 8 — Final cleanup & verification
 
@@ -230,3 +243,4 @@ breaking changes. Each phase is its own PR to keep blast radius small and bisect
 | 2026-06-21 | 4 | **Phase 4 complete** (branch `feature/auth-security-upgrade` off master). bcrypt→^6 (native rebuilt for v22), jsonwebtoken→^9 with explicit `algorithms: ['HS256']` on all 3 verify sites. Added HS384-rejection regression test (15/15). Live login E2E verified with real bcrypt/jwt. |
 | 2026-06-21 | 5 | **Phase 5 complete** (branch `feature/mongoose-upgrade` off master). Mongoose 5→6→7→8→9 (`^9.7.1`), one commit per major. Removed dead connect opts + set strictQuery; migrated cascade to `pre('deleteOne')` doc hook; deleteUser → async/await + `deleteOne()`; `.count()` → `countDocuments()`. backend-node-reviewer caught a Mailchimp `.end()` crash path + double-response, both fixed. 16/16 tests + seed + smoke green after each step. |
 | 2026-06-21 | 6 | **Phase 6 complete** (branch `feature/express-5-upgrade` off master). express 4.16 → ^5 (5.2.1). Fixed the latent 3-arg error handler (→ 4 args, JSON response) + fail-first regression test. Dropped server-side views: `res.render` → JSON in `routes/index.js` and the error handler; deleted `views/`, uninstalled `jade`. Removed unused `body-parser`. Route audit: no Express-5 breaking patterns. 18/18 tests; live smoke (`/`, `/books`, `/reviewers`, JSON 404) green. Audit 48 → 19. |
+| 2026-06-21 | 7 | **Phase 7 complete** (branch `feature/integrations-upgrade` off master). 3 commits. stripe 8 → ^22 (pinned apiVersion; fixed `confirm:true` → added `automatic_payment_methods {allow_redirects:'never'}`, verified live in Stripe test mode). nodemailer 6 → ^9 (SMTP auth verified via `.verify()`; fixed stray `;` in all 4 email templates). Mailchimp superagent → native `fetch` in 4 route files, removed superagent dep (read path verified live against both lists). 18/18 tests + boot smoke green. |

--- a/lib/email.js
+++ b/lib/email.js
@@ -15,7 +15,7 @@ const resetPasswordTemplate = (user, url) => {
   const from = 'resenansancho-no-reply@resenansancho.com';
   const to = user.email;
   const subject = 'Reseñan Sancho Password Reset';
-  const html = `;
+  const html = `
   <p>Hey ${user.name || user.email},</p>
   <a href=${url}>Haz click aquí para resetear la contraseña.</a>
   <p>Si no usas este enlace en una hora, caduca.</p>
@@ -29,7 +29,7 @@ const bookCopyRequestTemplate = (message, authorEmail, reviewerEmail, bookTitle,
   const from = 'resenansancho-no-reply@resenansancho.com';
   const to = authorEmail;
   const subject = '¡Enhorabuena, un reseñador está interesado en tu libro!';
-  const html = `;
+  const html = `
   <p>Hola,</p>
   <p>¡Tenemos una buena noticia, un reseñador literario quiere un ejemplar de tu libro ${bookTitle}!</p>
   <p>Este es su mensaje: </p>
@@ -48,7 +48,7 @@ const emailPromoTemplate = (authorEmail) => {
   const from = 'resenansancho-no-reply@resenansancho.com';
   const to = authorEmail;
   const subject = '¡Enhorabuena, la promoción de tu libro está en marcha!';
-  const html = `;
+  const html = `
   <p>Hola,</p>
   <p>¡La promoción de tu libro está en marcha!</p>
   <p>Para avanzar, necesitamos leer tu novela para recomendarla vía email a los reseñadores literarios.</p>
@@ -65,7 +65,7 @@ const newBookTemplate = (authorEmail, authorName, bookTitle) => {
   const from = 'resenansancho-no-reply@resenansancho.com';
   const to = authorEmail;
   const subject = `¡No te olvides de agregar ejemplares de ${bookTitle}!`;
-  const html = `;
+  const html = `
   <p>Hola ${authorName},</p>
   <p>¡Enhorabuena, ya has dado el primer paso para promocionar tu libro <b>${bookTitle}</b>!</p>
   <p>Esto es lo que puedes hacer ahora para <b>acelerar la promoción de tu libro</b>: </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "mongoose": "^9.7.1",
         "morgan": "^1.11.0",
         "nodemailer": "^9.0.3",
-        "stripe": "^22.3.1",
-        "superagent": "^3.8.3"
+        "stripe": "^22.3.1"
       },
       "devDependencies": {
         "jest": "^30.4.2",
@@ -1835,6 +1834,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-jest": {
@@ -2245,6 +2245,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2257,6 +2258,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
       "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2330,12 +2332,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2416,6 +2413,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2892,12 +2890,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2985,30 +2977,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
-      "license": "MIT",
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3370,12 +3338,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4419,24 +4381,17 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
       }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4446,6 +4401,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -5020,12 +4976,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5104,21 +5054,6 @@
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5446,15 +5381,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -5575,37 +5501,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/supertest": {
@@ -5889,12 +5784,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mongoose": "^9.7.1",
         "morgan": "^1.11.0",
         "nodemailer": "^6.4.6",
-        "stripe": "^8.51.0",
+        "stripe": "^22.3.1",
         "superagent": "^3.8.3"
       },
       "devDependencies": {
@@ -1349,6 +1349,7 @@
       "version": "25.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -5560,16 +5561,20 @@
       }
     },
     "node_modules/stripe": {
-      "version": "8.222.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.222.0.tgz",
-      "integrity": "sha512-hrA79fjmN2Eb6K3kxkDzU4ODeVGGjXQsuVaAPSUro6I9MM3X+BvIsVqdphm3BXWfimAGFvUqWtPtHy25mICY1w==",
+      "version": "22.3.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.1.tgz",
+      "integrity": "sha512-6XSLN0KK0IdfXqDHqMg6CDoO3eO62ye9dhzw0fZp55AUOzHR1YRJOqYHTsuCi4QJ4Ni/usEmXtq69c9ghKDmYw==",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": ">=8.1.0",
-        "qs": "^6.10.3"
-      },
       "engines": {
-        "node": "^8.1 || >=10.*"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/superagent": {
@@ -5804,6 +5809,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.7.1",
         "morgan": "^1.11.0",
-        "nodemailer": "^6.4.6",
+        "nodemailer": "^9.0.3",
         "stripe": "^22.3.1",
         "superagent": "^3.8.3"
       },
@@ -4696,9 +4696,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "mongoose": "^9.7.1",
     "morgan": "^1.11.0",
     "nodemailer": "^9.0.3",
-    "stripe": "^22.3.1",
-    "superagent": "^3.8.3"
+    "stripe": "^22.3.1"
   },
   "devDependencies": {
     "jest": "^30.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "private": true,
   "engines": {
     "node": ">=22 <23"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mongoose": "^9.7.1",
     "morgan": "^1.11.0",
     "nodemailer": "^6.4.6",
-    "stripe": "^8.51.0",
+    "stripe": "^22.3.1",
     "superagent": "^3.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.7.1",
     "morgan": "^1.11.0",
-    "nodemailer": "^6.4.6",
+    "nodemailer": "^9.0.3",
     "stripe": "^22.3.1",
     "superagent": "^3.8.3"
   },

--- a/routes/deleteUser.js
+++ b/routes/deleteUser.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const router = express.Router();
-var request = require('superagent');
 const User = require('../models/user');
 const Reviewer = require('../models/reviewer');
 const { verifyToken } = require('../lib/auth');
@@ -9,6 +8,7 @@ const mailchimpInstance = process.env.MAIL_CHIMP_INSTANCE;
 const listUniqueId = process.env.LIST_UNIQUE_ID;
 const url = `https://${mailchimpInstance}.api.mailchimp.com/3.0/lists/${listUniqueId}/members/`;
 const mailchimpApiKey = process.env.MAIL_CHIMP_API_KEY;
+const authHeader = 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64');
 
 router.delete('/', verifyToken(), async (req, res) => {
   try {
@@ -24,28 +24,25 @@ router.delete('/', verifyToken(), async (req, res) => {
     }
     const reviewer = await Reviewer.findOne({ author: userDoc._id });
     if (reviewer) {
-      request
-        .put(`${url}${user.email.toLowerCase()}`)
-        .set('Content-Type', 'application/json;charset=utf-8')
-        .set('Authorization', 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64'))
-        .send({
+      // Unsubscribe from Mailchimp before deleting. A transport failure now
+      // rejects and is caught by the outer try/catch (no detached callback).
+      const response = await fetch(`${url}${user.email.toLowerCase()}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8',
+          'Authorization': authHeader
+        },
+        body: JSON.stringify({
           'email_address': user.email,
           'status': 'unsubscribed',
         })
-        .end(async function (err, response) {
-          // This callback is detached from the outer try/catch, so handle its
-          // own failures: a transport error leaves `response` undefined.
-          try {
-            if (response && (response.status < 300 || response.status === 400)) {
-              await userDoc.deleteOne();
-              res.json({ success: true, message: 'usuario borrado' });
-            } else {
-              res.json({ success: false, message: 'usuario borrado, pero no se pudo eliminar de la lista de correos.' });
-            }
-          } catch (deleteErr) {
-            res.json({ success: false, message: 'Hubo un error al intentar borrar el usuario' });
-          }
-        });
+      });
+      if (response.status < 300 || response.status === 400) {
+        await userDoc.deleteOne();
+        res.json({ success: true, message: 'usuario borrado' });
+      } else {
+        res.json({ success: false, message: 'usuario borrado, pero no se pudo eliminar de la lista de correos.' });
+      }
     } else {
       await userDoc.deleteOne();
       res.json({ success: true, message: 'usuario borrado' });

--- a/routes/login.js
+++ b/routes/login.js
@@ -1,7 +1,6 @@
 const express = require('express');
 var jwt = require('jsonwebtoken');
 const router = express.Router();
-var request = require('superagent');
 const User = require('../models/user');
 const Reviewer = require('../models/reviewer');
 const bcrypt = require('bcrypt');
@@ -11,6 +10,7 @@ const mailchimpInstance = process.env.MAIL_CHIMP_INSTANCE;
 const listUniqueId = process.env.WRITERS_LIST_UNIQUE_ID;
 const url = `https://${mailchimpInstance}.api.mailchimp.com/3.0/lists/${listUniqueId}/members/`;
 const mailchimpApiKey = process.env.MAIL_CHIMP_API_KEY;
+const authHeader = 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64');
 
 router.post('/', async function (req, res) {
   try {
@@ -37,13 +37,26 @@ router.post('/', async function (req, res) {
       userLogged.token = token;
       const reviewer = await Reviewer.findOne({ author: user._id });
       if (user.emailAuthorListStatus) {
-        const response = await request
-          .get(`${url}${user.email.toLowerCase()}`)
-          .set('Content-Type', 'application/json;charset=utf-8')
-          .set('Authorization', 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64'));
-        if (response.body.status !== user.emailAuthorListStatus) {
-          await User.updateOne({ _id: user._id }, { emailAuthorListStatus: response.body.status });
-          userLogged.emailAuthorListStatus = response.body.status;
+        // Sync the author's Mailchimp subscription status. A failed lookup must
+        // never block login, so guard on response.ok and swallow errors: on a
+        // non-2xx Mailchimp response the body's `status` is a numeric HTTP code,
+        // not a subscription string, and must not be persisted.
+        try {
+          const response = await fetch(`${url}${user.email.toLowerCase()}`, {
+            headers: {
+              'Content-Type': 'application/json;charset=utf-8',
+              'Authorization': authHeader
+            }
+          });
+          if (response.ok) {
+            const body = await response.json();
+            if (body.status !== user.emailAuthorListStatus) {
+              await User.updateOne({ _id: user._id }, { emailAuthorListStatus: body.status });
+              userLogged.emailAuthorListStatus = body.status;
+            }
+          }
+        } catch (mcErr) {
+          // Mailchimp unreachable — skip the status sync, still log the user in.
         }
       }
       res.json({

--- a/routes/paymentCheckout.js
+++ b/routes/paymentCheckout.js
@@ -2,7 +2,9 @@ const express = require('express');
 const router = express.Router();
 const Book = require('../models/book');
 const { verifyToken } = require('../lib/auth');
-const stripe = require('stripe')(process.env.STRIPE_SECRET);
+// Pin the API version the installed SDK (v22) targets, so upgrading the SDK
+// never silently changes behavior via the account's default API version.
+const stripe = require('stripe')(process.env.STRIPE_SECRET, { apiVersion: '2026-06-24.dahlia' });
 const promotions = require('../utils/constants/promotions');
 const {
   transporter,
@@ -29,7 +31,11 @@ router.post('/', verifyToken(), async function (req, res) {
       currency: 'EUR',
       description: 'Reseñan Sancho',
       payment_method: id,
-      confirm: true
+      confirm: true,
+      // Server-side card charge with no redirect flow: opt out of redirect-based
+      // methods so Stripe doesn't require a return_url (required since the API
+      // versions the v22 SDK targets).
+      automatic_payment_methods: { enabled: true, allow_redirects: 'never' }
     });
     const promoInfo = {};
     promoInfo.copies = book.copies + copies;

--- a/routes/registerReviewer.js
+++ b/routes/registerReviewer.js
@@ -2,7 +2,6 @@
 
 const express = require('express');
 const router = express.Router();
-var request = require('superagent');
 const crypto = require('crypto');
 const Reviewer = require('../models/reviewer');
 const User = require('../models/user');
@@ -12,6 +11,10 @@ const mailchimpInstance = process.env.MAIL_CHIMP_INSTANCE;
 const listUniqueId = process.env.LIST_UNIQUE_ID;
 const url = `https://${mailchimpInstance}.api.mailchimp.com/3.0/lists/${listUniqueId}/members/`;
 const mailchimpApiKey = process.env.MAIL_CHIMP_API_KEY;
+const mailchimpHeaders = {
+  'Content-Type': 'application/json;charset=utf-8',
+  'Authorization': 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64')
+};
 
 const genresMapper = [
   { name: 'adventure', code: 'ADV' },
@@ -79,11 +82,10 @@ router.post('/', async function (req, res) {
     const formatsForMailchimp = formatsMapper.reduce((acum, curr) => (
       formats.includes(curr.name) ? { ...acum, [curr.code]: 'true' } : { ...acum, [curr.code]: 'false' }), {});
     const userCountry = user.country ? user.country : 'N/A';
-    request
-      .post(url)
-      .set('Content-Type', 'application/json;charset=utf-8')
-      .set('Authorization', 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64'))
-      .send({
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: mailchimpHeaders,
+      body: JSON.stringify({
         'email_address': user.email,
         'status': 'subscribed',
         'merge_fields': {
@@ -93,18 +95,16 @@ router.post('/', async function (req, res) {
           ...formatsForMailchimp
         }
       })
-      .end(function (err, response) {
-        console.log("responseeeeeeeee", err, response.status, response.text)
-        if (!err && response && response.status >= 200 && response.status < 300) {
-          res.json({
-            success: true,
-            message: '¡Enhorabuena! Tu perfil de reseñadora literaria fue dado de alta.',
-            reviewer: newReviewer
-          });
-        } else {
-          res.json({ success: false, message: 'no se pudo guardar algunos cambios.' });
-        }
+    });
+    if (response.status >= 200 && response.status < 300) {
+      res.json({
+        success: true,
+        message: '¡Enhorabuena! Tu perfil de reseñadora literaria fue dado de alta.',
+        reviewer: newReviewer
       });
+    } else {
+      res.json({ success: false, message: 'no se pudo guardar algunos cambios.' });
+    }
   } catch (error) {
     res.json(error);
   }
@@ -155,18 +155,17 @@ router.put('/', verifyToken(), async (req, res) => {
       formats.includes(curr.name) ? { ...acum, [curr.code]: 'true' } : { ...acum, [curr.code]: 'false' }), {});
     const userCountry = user.country ? user.country : 'N/A';
     const subscriberHash = crypto.createHash('md5').update(user.email.toLowerCase()).digest('hex');
-    const response = await request
-      .get(`${url}${subscriberHash}`)
-      .set('Content-Type', 'application/json;charset=utf-8')
-      .set('Authorization', 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64'));
+    // Read the member's current subscription status so the PUT (an upsert)
+    // preserves it while updating the merge fields.
+    const getResponse = await fetch(`${url}${subscriberHash}`, { headers: mailchimpHeaders });
+    const member = await getResponse.json();
 
-    request
-      .put(`${url}${subscriberHash}`)
-      .set('Content-Type', 'application/json;charset=utf-8')
-      .set('Authorization', 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64'))
-      .send({
+    const putResponse = await fetch(`${url}${subscriberHash}`, {
+      method: 'PUT',
+      headers: mailchimpHeaders,
+      body: JSON.stringify({
         'email_address': user.email,
-        'status': response.body.status,
+        'status': member.status,
         'merge_fields': {
           'FNAME': user.name,
           'PAIS': userCountry,
@@ -174,13 +173,12 @@ router.put('/', verifyToken(), async (req, res) => {
           ...formatsForMailchimp,
         }
       })
-      .end(function (err, response) {
-        if (!err && response && response.status >= 200 && response.status < 300) {
-          res.json({ success: true, message: '¡Has actualizado tu perfil de reseñadora literaria correctamente!', reviewer: reviewerUpdated });
-        } else {
-          res.json({ success: false, message: 'no se pudo guardar los cambios' });
-        }
-      });
+    });
+    if (putResponse.status >= 200 && putResponse.status < 300) {
+      res.json({ success: true, message: '¡Has actualizado tu perfil de reseñadora literaria correctamente!', reviewer: reviewerUpdated });
+    } else {
+      res.json({ success: false, message: 'no se pudo guardar los cambios' });
+    }
   } catch (error) {
     res.json(error);
   }

--- a/routes/registerReviewer.js
+++ b/routes/registerReviewer.js
@@ -156,8 +156,14 @@ router.put('/', verifyToken(), async (req, res) => {
     const userCountry = user.country ? user.country : 'N/A';
     const subscriberHash = crypto.createHash('md5').update(user.email.toLowerCase()).digest('hex');
     // Read the member's current subscription status so the PUT (an upsert)
-    // preserves it while updating the merge fields.
+    // preserves it while updating the merge fields. Unlike superagent, fetch
+    // does not throw on a 404, and a non-2xx Mailchimp body's `status` is a
+    // numeric HTTP code — never send that back as a subscription status.
     const getResponse = await fetch(`${url}${subscriberHash}`, { headers: mailchimpHeaders });
+    if (!getResponse.ok) {
+      res.json({ success: false, message: 'no se pudo guardar los cambios' });
+      return;
+    }
     const member = await getResponse.json();
 
     const putResponse = await fetch(`${url}${subscriberHash}`, {

--- a/routes/suscribeAuthor.js
+++ b/routes/suscribeAuthor.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const router = express.Router();
-var request = require('superagent');
 const { verifyToken } = require('../lib/auth');
 const User = require('../models/user');
 
@@ -8,6 +7,11 @@ const mailchimpInstance = process.env.MAIL_CHIMP_INSTANCE;
 const listUniqueId = process.env.WRITERS_LIST_UNIQUE_ID;
 const url = `https://${mailchimpInstance}.api.mailchimp.com/3.0/lists/${listUniqueId}/members/`;
 const mailchimpApiKey = process.env.MAIL_CHIMP_API_KEY;
+const authHeader = 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64');
+const mailchimpHeaders = {
+  'Content-Type': 'application/json;charset=utf-8',
+  'Authorization': authHeader
+};
 
 router.post('/', verifyToken(), async function (req, res) {
   try {
@@ -18,52 +22,38 @@ router.post('/', verifyToken(), async function (req, res) {
       return;
     }
     const userToSuscribe = await User.findOne({ _id });
+    // Mailchimp returns 400 when the member already exists; the previous code
+    // treated that as success too (the local status is still updated).
+    let response, failMessage;
     if (!userToSuscribe.emailAuthorListStatus) {
-      request
-        .post(url)
-        .set('Content-Type', 'application/json;charset=utf-8')
-        .set('Authorization', 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64'))
-        .send({
+      response = await fetch(url, {
+        method: 'POST',
+        headers: mailchimpHeaders,
+        body: JSON.stringify({
           'email_address': user.email,
           'status': status,
           'merge_fields': {
             'FNAME': user.name,
           }
         })
-        .end(async function (err, response) {
-          if (response.status < 300 || (response.status === 400)) {
-            await User.updateOne({ _id }, {
-              emailAuthorListStatus: status
-            });
-            const message = status === 'subscribed'
-              ? '¡Genial, ya estás en la lista para recibir consejos!'
-              : 'Ya no te enviaremos más consejos por email :(';
-            res.json({ success: true, message });
-          } else {
-            res.json({ success: false, message: 'Hubo un error y no se pudo guardar los cambios.' });
-          }
-        });
+      });
+      failMessage = 'Hubo un error y no se pudo guardar los cambios.';
     } else {
-      request
-        .patch(`${url}${user.email.toLowerCase()}`)
-        .set('Content-Type', 'application/json;charset=utf-8')
-        .set('Authorization', 'Basic ' + Buffer.from('anystring:' + mailchimpApiKey).toString('base64'))
-        .send({
-          'status': status,
-        })
-        .end(async function (err, response) {
-          if (response.status < 300 || (response.status === 400)) {
-            await User.updateOne({ _id }, {
-              emailAuthorListStatus: status
-            });
-            const message = status === 'subscribed'
-              ? '¡Genial, ya estás en la lista para recibir consejos!'
-              : 'Ya no te enviaremos más consejos por email :(';
-            res.json({ success: true, message });
-          } else {
-            res.json({ success: false, message: 'Hubo un error y no se pudo actualizar los cambios.' });
-          }
-        });
+      response = await fetch(`${url}${user.email.toLowerCase()}`, {
+        method: 'PATCH',
+        headers: mailchimpHeaders,
+        body: JSON.stringify({ 'status': status })
+      });
+      failMessage = 'Hubo un error y no se pudo actualizar los cambios.';
+    }
+    if (response.status < 300 || response.status === 400) {
+      await User.updateOne({ _id }, { emailAuthorListStatus: status });
+      const message = status === 'subscribed'
+        ? '¡Genial, ya estás en la lista para recibir consejos!'
+        : 'Ya no te enviaremos más consejos por email :(';
+      res.json({ success: true, message });
+    } else {
+      res.json({ success: false, message: failMessage });
     }
   } catch (error) {
     res.json({ error });

--- a/tests/paymentCheckout.test.js
+++ b/tests/paymentCheckout.test.js
@@ -46,7 +46,12 @@ describe('POST /paymentCheckout', () => {
       .send({ author: 'owner1', id: 'pm_card', chosenPromo: 2, bookId: 'b1' });
 
     expect(stripe.__create).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 990, currency: 'EUR', confirm: true })
+      expect.objectContaining({
+        amount: 990,
+        currency: 'EUR',
+        confirm: true,
+        automatic_payment_methods: { enabled: true, allow_redirects: 'never' }
+      })
     );
     expect(Book.updateOne).toHaveBeenCalledWith({ _id: 'b1' }, expect.objectContaining({ copies: 5 }));
     expect(res.body.success).toBe(true);

--- a/tests/registerReviewer.test.js
+++ b/tests/registerReviewer.test.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-undef */
+process.env.JWT_SECRET = 'test-secret';
+// registerReviewer builds the Mailchimp URL from these at module load.
+process.env.MAIL_CHIMP_INSTANCE = 'us1';
+process.env.LIST_UNIQUE_ID = 'list123';
+process.env.MAIL_CHIMP_API_KEY = 'key123';
+
+// Block side effects at import time.
+jest.mock('../lib/connectMongoose', () => ({}));
+jest.mock('stripe', () => jest.fn(() => ({ paymentIntents: { create: jest.fn() } })));
+jest.mock('../models/user', () => require('./helpers/modelMock').makeModelMock(['findOne']));
+jest.mock('../models/reviewer', () => require('./helpers/modelMock').makeModelMock(['findOne', 'updateOne']));
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const User = require('../models/user');
+const Reviewer = require('../models/reviewer');
+const app = require('../app');
+
+const tokenFor = (user) => jwt.sign({ user }, process.env.JWT_SECRET);
+
+// A valid Mailchimp member GET response (subscription status is a string).
+const okMember = () => ({ ok: true, status: 200, json: async () => ({ status: 'subscribed' }) });
+// Mailchimp "member not found" — note: `status` here is the numeric HTTP code.
+const notFound = () => ({ ok: false, status: 404, json: async () => ({ status: 404, title: 'Resource Not Found' }) });
+
+describe('PUT /registerReviewer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    User.findOne.mockResolvedValue({ _id: 'u1', email: 'a@b.com', name: 'Ana', country: 'ES' });
+    Reviewer.updateOne.mockResolvedValue({});
+  });
+
+  const body = { author: 'u1', genres: ['romantic'], formats: ['papel'], blog: '', booktube: '', bookstagram: '', goodreads: '', amazon: '', description: 'x' };
+
+  test('updates the profile when the Mailchimp member exists', async () => {
+    global.fetch.mockResolvedValueOnce(okMember())            // GET member
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) }); // PUT upsert
+
+    const res = await request(app)
+      .put('/registerReviewer')
+      .set('access-token', tokenFor({ _id: 'u1' }))
+      .send(body);
+
+    expect(res.body.success).toBe(true);
+    // The PUT must carry the member's real subscription status string.
+    const putCall = global.fetch.mock.calls[1];
+    expect(JSON.parse(putCall[1].body).status).toBe('subscribed');
+  });
+
+  // Regression: with superagent a 404 GET threw and skipped the PUT. With fetch
+  // (no throw on 404) the handler must NOT send the numeric HTTP code (404) as
+  // the subscription status — it should bail out before the PUT.
+  test('does not send a numeric status when the Mailchimp member is missing', async () => {
+    global.fetch.mockResolvedValueOnce(notFound()); // GET member → 404
+
+    const res = await request(app)
+      .put('/registerReviewer')
+      .set('access-token', tokenFor({ _id: 'u1' }))
+      .send(body);
+
+    // No PUT should be attempted after a failed lookup.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(res.body).toEqual({ success: false, message: 'no se pudo guardar los cambios' });
+  });
+});


### PR DESCRIPTION
## Phase 7 — Integrations (Stripe, Nodemailer, Mailchimp)

Seventh phase of the dependency/Node modernization (see `docs/dependency-upgrade-plan.md`). Three independent sub-phases, one commit each, plus a reviewer-found fix.

### Stripe 8 → 22 (22.3.1)
- Pinned `apiVersion: '2026-06-24.dahlia'` (the version the v22 SDK targets) so an SDK bump can't silently change behavior via the account default.
- **Real breaking change fixed:** under the pinned API, `paymentIntents.create` with a bare `confirm: true` now errors (`"...you must provide a return_url"`) because the account has dashboard-enabled redirect-capable methods. Added `automatic_payment_methods: { enabled: true, allow_redirects: 'never' }` (server-side card charge, no redirect flow). **Verified live in Stripe test mode** (`pm_card_visa` → `succeeded`).
- Updated the `paymentCheckout` test to assert the new option.

### Nodemailer 6 → 9 (9.0.3)
- `createTransport`/`sendMail` API unchanged; **SMTP auth verified live** via `transporter.verify()` (no outbound send).
- Fixed a long-standing bug: every HTML template opened with `` `; `` (backtick + literal semicolon), so each email body started with a stray `;`. Removed from all four templates in `lib/email.js`.

### Mailchimp: superagent → native `fetch`
- Ported all four callers (`login.js`, `suscribeAuthor.js`, `deleteUser.js`, `registerReviewer.js`) from `superagent` to the global `fetch` (Node 22), and **removed the deprecated `superagent` dependency**.
- Preserved the Basic-auth header, JSON bodies, and the "treat HTTP 400 as success" semantics Mailchimp relies on. **Read path verified live** against both real lists (GET → 200).
- Robustness gains: login's status sync can no longer abort login on a Mailchimp outage (guarded on `response.ok`, so a numeric error `status` is never persisted); `deleteUser`/`suscribeAuthor` fetches now live inside the existing try/catch (no detached `.end()` callbacks); dropped a stray debug `console.log` in `registerReviewer`.

### Review (backend-node-reviewer)
- **Blocker found & fixed:** `registerReviewer` PUT — because `fetch` (unlike superagent) doesn't throw on a 404, a missing member's numeric `status: 404` was being sent back as the subscriber's subscription status. Guarded on `getResponse.ok`; shipped with a **fail-first regression test** (`tests/registerReviewer.test.js`).
- Pre-existing items noted for a later pass (out of scope here): `registerReviewer` POST/PUT don't treat 400 as success like the other callers and leak raw errors; `deleteUser` reports "usuario borrado" without deleting when the Mailchimp unsubscribe fails; no Stripe idempotency key.

### Tests & verification
- `npm test` → **20/20** on Node 22 (added the 2 registerReviewer tests).
- Live server boot: `/`, `/books`, `/reviewers` all 200.
- Write paths against the production Mailchimp lists were **not** exercised (validated structurally + via the live read path) to avoid mutating real member data.

### Version
`2.1.0` → `3.0.0` (MAJOR: Stripe 8→22, Nodemailer 6→9, `superagent` removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)