### PR TITLE
Add 24h cooldown between book orders per reviewer

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -30,7 +30,8 @@ const UserSchema = Schema({
   },
   avatar: String,
   resetPasswordToken: String,
-  resetPasswordExpires: Date
+  resetPasswordExpires: Date,
+  lastBookOrderAt: Date
 });
 
 UserSchema.statics.hashPassword = (plainPassword) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": true,
   "engines": {
     "node": ">=22 <23"

--- a/routes/orderBook.js
+++ b/routes/orderBook.js
@@ -7,6 +7,7 @@ const {
   transporter,
   bookCopyRequestTemplate
 } = require('../lib/email');
+const { ORDER_COOLDOWN_HOURS, MS_PER_HOUR } = require('../utils/constants/orders');
 
 router.post('/', verifyToken(), async function (req, res) {
   try {
@@ -38,6 +39,20 @@ router.post('/', verifyToken(), async function (req, res) {
       return;
     }
 
+    // Verify the reviewer hasn't ordered another book within the cooldown window
+    const reviewerUser = await User.findOne({ _id: reviewer });
+    if (reviewerUser && reviewerUser.lastBookOrderAt) {
+      const hoursSince = (Date.now() - reviewerUser.lastBookOrderAt.getTime()) / MS_PER_HOUR;
+      if (hoursSince < ORDER_COOLDOWN_HOURS) {
+        const hoursLeft = Math.ceil(ORDER_COOLDOWN_HOURS - hoursSince);
+        res.json({
+          success: false,
+          message: `Ya has solicitado un libro recientemente, debes esperar ${hoursLeft} horas para poder solicitar otro`
+        });
+        return;
+      }
+    }
+
     //Send email to author
     const author = await User.findOne({ _id: book.author });
     const emailTemplate = bookCopyRequestTemplate(message, author.email, user.email, book.title, book.copies - 1);
@@ -56,6 +71,9 @@ router.post('/', verifyToken(), async function (req, res) {
       { _id },
       { $addToSet: { reviewersOrders: reviewer }, $inc: { copies: -1 } }
     );
+
+    // Record the order time to enforce the cooldown on the next request
+    await User.updateOne({ _id: reviewer }, { lastBookOrderAt: new Date() });
 
     res.json({ success: true, message: 'Enhorabuena, el ejemplar ha sido solicitado a su autor.' });
   } catch (error) {

--- a/tests/orderBook.test.js
+++ b/tests/orderBook.test.js
@@ -1,0 +1,85 @@
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../lib/connectMongoose', () => ({}));
+jest.mock('stripe', () => jest.fn(() => ({ paymentIntents: { create: jest.fn() } })));
+jest.mock('../models/user', () => require('./helpers/modelMock').makeModelMock(['findOne', 'updateOne']));
+jest.mock('../models/book', () => require('./helpers/modelMock').makeModelMock(['findOne', 'updateOne']));
+jest.mock('../models/reviewer', () => require('./helpers/modelMock').makeModelMock(['findOne']));
+jest.mock('../lib/email', () => ({
+  transporter: { sendMail: jest.fn((tpl, cb) => cb(null)) },
+  bookCopyRequestTemplate: jest.fn(() => ({}))
+}));
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const User = require('../models/user');
+const Book = require('../models/book');
+const app = require('../app');
+
+const REVIEWER_ID = 'u1';
+const tokenFor = (user) => jwt.sign({ user }, process.env.JWT_SECRET);
+const hoursAgo = (h) => new Date(Date.now() - h * 60 * 60 * 1000);
+
+// The route reads the reviewer's own user doc first, then the book's author doc.
+const mockUsers = (reviewerDoc) => {
+  User.findOne.mockImplementation(({ _id }) =>
+    Promise.resolve(_id === REVIEWER_ID ? reviewerDoc : { email: 'author@b.com' })
+  );
+};
+
+const orderRequest = () =>
+  request(app)
+    .post('/orderBook')
+    .set('access-token', tokenFor({ _id: REVIEWER_ID, email: 'r@b.com' }))
+    .send({ reviewer: REVIEWER_ID, book: 'b1', message: 'hola' });
+
+describe('orderBook routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Book.findOne.mockResolvedValue({
+      _id: 'b1',
+      copies: 3,
+      reviewersOrders: [],
+      author: { equals: () => false }
+    });
+    Book.updateOne.mockResolvedValue({});
+    User.updateOne.mockResolvedValue({});
+  });
+
+  test('blocks a second order inside the 24h cooldown', async () => {
+    mockUsers({ _id: REVIEWER_ID, lastBookOrderAt: hoursAgo(2) });
+
+    const res = await orderRequest();
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/debes esperar 22 horas/);
+    expect(Book.updateOne).not.toHaveBeenCalled();
+    expect(User.updateOne).not.toHaveBeenCalled();
+  });
+
+  test('allows a new order once the cooldown has elapsed', async () => {
+    mockUsers({ _id: REVIEWER_ID, lastBookOrderAt: hoursAgo(25) });
+
+    const res = await orderRequest();
+
+    expect(res.body.success).toBe(true);
+    expect(Book.updateOne).toHaveBeenCalledTimes(1);
+    expect(User.updateOne).toHaveBeenCalledWith(
+      { _id: REVIEWER_ID },
+      { lastBookOrderAt: expect.any(Date) }
+    );
+  });
+
+  test('allows a first-ever order and stamps the order time', async () => {
+    mockUsers({ _id: REVIEWER_ID });
+
+    const res = await orderRequest();
+
+    expect(res.body.success).toBe(true);
+    expect(User.updateOne).toHaveBeenCalledWith(
+      { _id: REVIEWER_ID },
+      { lastBookOrderAt: expect.any(Date) }
+    );
+  });
+});

--- a/utils/constants/orders.js
+++ b/utils/constants/orders.js
@@ -1,0 +1,4 @@
+const ORDER_COOLDOWN_HOURS = 24;
+const MS_PER_HOUR = 1000 * 60 * 60;
+
+module.exports = { ORDER_COOLDOWN_HOURS, MS_PER_HOUR };


### PR DESCRIPTION
## Qué hace

Introduce un límite temporal: un reseñador puede solicitar como máximo **un libro cada 24 horas**. Hasta ahora la única restricción evitaba pedir el **mismo** libro dos veces, pero nada impedía solicitar muchos libros distintos a la vez.

Cuando un reseñador lo intenta antes de tiempo, la API responde:

> `Ya has solicitado un libro recientemente, debes esperar XX horas para poder solicitar otro`

donde `XX` son las horas enteras que faltan (redondeadas hacia arriba con `Math.ceil`) para completar las 24h desde su último pedido.

## Cambios

- **`models/user.js`** — nuevo campo `lastBookOrderAt: Date` (sin valor por defecto; un reseñador nuevo no tiene cooldown).
- **`utils/constants/orders.js`** (nuevo) — `ORDER_COOLDOWN_HOURS = 24` y `MS_PER_HOUR`, siguiendo el estilo de `promotions.js`.
- **`routes/orderBook.js`** — tras las validaciones existentes y antes de enviar el email al autor, lee el documento del reseñador y rechaza si han pasado menos de 24h desde `lastBookOrderAt`. En un pedido correcto, sella `lastBookOrderAt = new Date()` junto al `Book.updateOne` existente.
- **`tests/orderBook.test.js`** (nuevo) — cubre: cooldown bloquea el pedido (mensaje "22 horas" y sin escrituras), cooldown expirado permite el pedido, y primer pedido de un reseñador nuevo.

## Detalle de diseño

El campo `reviewer` que envía el frontend a `/orderBook` es el `_id` del **usuario** (así funcionan ya el chequeo de permisos y `book.reviewersOrders`), por lo que el cooldown queda correctamente asociado al usuario a través de todos los libros — justo el abuso de "varios libros a la vez".

Orden de comprobaciones: copias → ya pidió este libro → libro propio → **cooldown** → email → persistir. Se mantienen los mensajes específicos antes del genérico para dar el error más preciso.

## Verificación

- `npm run lint` — limpio.
- `npm test` — 23/23 en verde, incluidos los 3 tests nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)