### PR TITLE
Add GET /version endpoint

### DIFF
--- a/lib/namedRoutes.js
+++ b/lib/namedRoutes.js
@@ -15,5 +15,6 @@ module.exports = {
   'reviewer': '/reviewer',
   'suscribeAuthor': '/suscribeAuthor',
   'update': '/update',
-  'users': '/users'
+  'users': '/users',
+  'version': '/version'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "engines": {
     "node": ">=22 <23"

--- a/routes/router.js
+++ b/routes/router.js
@@ -19,6 +19,7 @@ const reviewersRouter = require('./reviewers');
 const suscribeAuthorRouter = require('./suscribeAuthor');
 const updateRouter = require('./update');
 const usersRouter = require('./users');
+const versionRouter = require('./version');
 
 // Router class
 class Router {
@@ -40,6 +41,7 @@ class Router {
     app.use(namedRoutes.suscribeAuthor, suscribeAuthorRouter);
     app.use(namedRoutes.update, updateRouter);
     app.use(namedRoutes.users, usersRouter);
+    app.use(namedRoutes.version, versionRouter);
   }
 }
 

--- a/routes/version.js
+++ b/routes/version.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const { version } = require('../package.json');
+
+/* GET deployed backend version. */
+router.get('/', function (req, res) {
+  res.json({ version });
+});
+
+module.exports = router;

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -1,0 +1,20 @@
+
+process.env.JWT_SECRET = 'test-secret';
+
+// app.js wires up Mongoose at require time; keep it from touching a real DB.
+jest.mock('../lib/connectMongoose', () => ({}));
+jest.mock('stripe', () => jest.fn(() => ({ paymentIntents: { create: jest.fn() } })));
+
+const request = require('supertest');
+const app = require('../app');
+const { version } = require('../package.json');
+
+describe('GET /version', () => {
+  test('returns the current backend version as JSON', async () => {
+    const res = await request(app).get('/version');
+
+    expect(res.status).toBe(200);
+    expect(res.type).toMatch(/json/);
+    expect(res.body).toEqual({ version });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a simple public `GET /version` endpoint so the deployed backend version can be checked in production by just opening the URL in a browser.

Returns the current version straight from `package.json`:
```json
{ "version": "3.2.0" }
```

Because it reads from `package.json`, it always reflects the actually-deployed version — no manual sync needed.

## Changes
- `routes/version.js` — new self-contained router
- `lib/namedRoutes.js` — registered `/version` path
- `routes/router.js` — mounted the router (following project convention)
- `tests/version.test.js` — asserts `200` + `{ version }` matching `package.json`
- Version bump `3.1.0 → 3.2.0` (MINOR: new endpoint)

## Testing
- `npm test` → 24/24 passing
- `npm run lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)