### PR TITLE
Add GET /home/highlights endpoint for home content blocks

### DIFF
--- a/docs/home-highlights-spec.md
+++ b/docs/home-highlights-spec.md
@@ -24,10 +24,14 @@ existentes en producción.
 
 ## Endpoint
 
-### `GET /api/home/highlights`
+### `GET /home/highlights`
 
 Devuelve ambos bloques en una sola respuesta, para evitar dos round-trips
-desde `getServerSideProps` de home.
+desde `getServerSideProps` de home. Público, sin `verifyToken()`.
+
+> El backend monta todas sus rutas en la raíz (`/books`, `/login`, `/version`);
+> no existe prefijo `/api`. Si el frontend llama a `/api/home/highlights`, ese
+> `/api` es el rewrite/proxy de Next, no parte del path del backend.
 
 #### Response
 
@@ -36,34 +40,48 @@ desde `getServerSideProps` de home.
   "featuredBooks": [
     {
       "id": "...",
-      "titulo": "...",
-      "autor": "...",
-      "genero": "novela-historica",
-      "ejemplaresDisponibles": 8,
-      "slug": "..."
+      "title": "...",
+      "author": "Carlos Zafón",
+      "genre": "HIF",
+      "copies": 8
     }
   ],
   "topGenres": [
-    { "slug": "novela-historica", "nombre": "Novela histórica", "totalLibros": 142 },
-    { "slug": "poesia", "nombre": "Poesía", "totalLibros": 98 },
-    { "slug": "ensayo", "nombre": "Ensayo", "totalLibros": 76 }
+    { "code": "HIF", "totalBooks": 142 },
+    { "code": "POE", "totalBooks": 98 },
+    { "code": "ADV", "totalBooks": 76 }
   ],
   "cachedAt": "2026-08-15T10:00:00Z"
 }
 ```
 
-- `featuredBooks`: top 4 libros ordenados por `ejemplaresDisponibles desc`.
-- `topGenres`: top 3 géneros ordenados por cantidad total de libros
-  disponibles en ese género.
-- `slug` en ambos bloques mapea directamente a rutas ya existentes en
-  producción:
-  - Libro → página de detalle (`/books/[id]`, SSR desde PR #64)
-  - Género → `/libros/genero/<slug>`
-- El mapping código interno → slug usa la tabla bidireccional ya definida en
-  `src/data/genres.ts`. A decidir con `senior-backend`: si el backend
-  mantiene su propia copia del mapping o si el frontend traduce el código
-  interno (`genero`) al slug antes de construir el link — según dónde viva
-  ya esa lógica en el código actual.
+Las claves van en inglés, como el modelo y el resto de endpoints (`/books`).
+
+- `featuredBooks`: top 4 libros ordenados por `copies desc` (con `create_at
+  desc` como desempate, para que el orden sea determinista).
+- `topGenres`: top 3 géneros ordenados por cantidad de libros disponibles en
+  ese género.
+- Ambos bloques cuentan **sólo libros con `copies > 0`**: un libro sin
+  ejemplares no es solicitable, así que ni se destaca ni infla su género. Es el
+  mismo criterio de disponibilidad que ya usa `routes/books.js`.
+- `author` viene aplanado a un string de display (`name + lastName`); la card
+  sólo necesita un nombre y así no se filtran internos del usuario.
+- El libro no tiene `slug` en el modelo, y el destino del link es
+  `/books/[id]` (SSR desde PR #64), así que se devuelve `id` a secas.
+
+#### Mapping de género (decidido)
+
+El backend devuelve el **código interno de 3 letras**
+(`utils/constants/genres.js`: `HIF`, `POE`, `ADV`…) y el frontend lo traduce a
+slug y a nombre en español con la tabla bidireccional que ya posee en
+`src/data/genres.ts`. Así el mapping tiene una sola fuente de verdad y el
+backend no duplica datos de presentación.
+
+- Género → `/libros/genero/<slug>`, con el slug resuelto en frontend.
+- **Ojo**: hay 17 códigos en `utils/constants/genres.js`. Antes de construir
+  los links conviene verificar que `src/data/genres.ts` los cubre todos — los
+  ejemplos originales de este documento (`ensayo`, `novela-historica`) no
+  corresponden uno a uno con esos códigos.
 
 ---
 
@@ -82,32 +100,22 @@ suficiente y evita añadir Redis o un documento de caché en Mongo.
   salvo, como mucho, una vez al día.
 - **Sin invalidación activa** en esta v1.
 
-### Implementación de referencia
+### Implementación
 
-```js
-let cache = { data: null, expiresAt: 0 };
+Vive en `lib/homeHighlights.js`, que expone `getHomeHighlights()` y
+`invalidateHomeHighlights()`. Sigue el esquema de referencia con dos matices
+añadidos al implementarlo:
 
-async function getHomeHighlights() {
-  const now = Date.now();
-  if (cache.data && now < cache.expiresAt) {
-    return cache.data;
-  }
+- **De-duplicación de misses concurrentes**: se guarda la promesa en vuelo, de
+  forma que una caché fría (arranque de dyno) dispara una sola ronda de
+  queries y no una por request simultánea.
+- **Los errores no se cachean**: si una query falla no se guarda nada, así que
+  el siguiente request reintenta en vez de servir una caché envenenada. La ruta
+  responde `500` con mensaje en español.
 
-  const [featuredBooks, topGenres] = await Promise.all([
-    getFeaturedBooks(),
-    getTopGenres(),
-  ]);
-
-  cache.data = {
-    featuredBooks,
-    topGenres,
-    cachedAt: new Date().toISOString(),
-  };
-  cache.expiresAt = now + 24 * 60 * 60 * 1000;
-
-  return cache.data;
-}
-```
+`invalidateHomeHighlights()` no se usa desde la API en esta v1 (no hay
+invalidación activa); queda como gancho para el caso futuro descrito más abajo
+y lo usan los tests para partir de caché fría.
 
 ### Notas
 
@@ -118,9 +126,9 @@ async function getHomeHighlights() {
 - **Evolución futura**: si en algún momento las compras de servicios de
   promoción (`boost25`, `featuredWeek`) deben afectar a `featuredBooks` en
   tiempo real, se puede invalidar la caché puntualmente al confirmarse un
-  pago (`cache.expiresAt = 0`). No es necesario para esta v1 — de momento el
-  ranking de `featuredBooks` es puramente orgánico, por
-  `ejemplaresDisponibles`.
+  pago — para eso está `invalidateHomeHighlights()`. No es necesario para esta
+  v1: de momento el ranking de `featuredBooks` es puramente orgánico, por
+  `copies`.
 - Si en el futuro se pasa a multi-dyno, esta caché en memoria dejaría de ser
   válida (cada dyno tendría su propia copia, recalculando de forma
   independiente al expirar su TTL) y habría que revisar la estrategia
@@ -132,8 +140,9 @@ async function getHomeHighlights() {
 
 En `getServerSideProps` de home:
 
-- Una sola llamada a `GET /api/home/highlights`, en paralelo con cualquier
-  otra data que ya se esté pidiendo en esa misma función (`Promise.all`).
+- Una sola llamada a `GET /home/highlights` (ver nota sobre el prefijo `/api`
+  más arriba), en paralelo con cualquier otra data que ya se esté pidiendo en
+  esa misma función (`Promise.all`).
 - En el peor caso (caché backend fría), el usuario que dispara el
   recálculo paga el coste del aggregate — con un TTL de 24h esto es un
   evento rarísimo y no justifica loading states especiales.
@@ -142,35 +151,68 @@ En `getServerSideProps` de home:
 
 ---
 
-## Queries de referencia (MongoDB)
+## Queries (MongoDB)
+
+Los nombres de campo de este documento eran provisionales; el modelo real
+(`models/book.js`) usa `title`, `author`, `genre` y `copies`. `copies` **es**
+el número de ejemplares disponibles: `routes/orderBook.js` lo decrementa con
+`$inc` en cada solicitud.
 
 ### `getFeaturedBooks()`
 
-Ordenar por `ejemplaresDisponibles` descendente, limitar a 4, proyectar solo
-los campos necesarios para la card (`titulo`, `autor`, `genero`,
-`ejemplaresDisponibles`, `slug`/`id`).
+```js
+Book.find({ copies: { $gt: 0 } })
+  .sort({ copies: -1, create_at: -1 })
+  .limit(4)
+  .select('title genre copies')
+  .populate('author', 'name lastName')
+  .lean();
+```
 
 ### `getTopGenres()`
 
-Aggregate agrupando por `genero`, contando documentos, ordenando por conteo
-descendente, limitando a 3. Traducir el código interno de género a nombre
-en español (ya existente en `src/data/genres.ts`) y a slug para el link.
+```js
+Book.aggregate([
+  { $match: { copies: { $gt: 0 } } },
+  { $group: { _id: '$genre', totalBooks: { $sum: 1 } } },
+  { $sort: { totalBooks: -1, _id: 1 } },
+  { $limit: 3 },
+]);
+```
 
-Ambas queries son responsabilidad de `senior-backend` para definir los
-índices necesarios (por ejemplo, índice sobre `ejemplaresDisponibles` si no
-existe ya) antes de implementar.
+### Índices
+
+No existía índice ni sobre `copies` ni sobre `genre`. Se añaden dos en
+`models/book.js`:
+
+- `{ copies: -1, create_at: -1 }` — cubre el match por rango y el sort de
+  `getFeaturedBooks()`.
+- `{ copies: 1, genre: 1 }` — permite que el aggregate agrupe desde el índice
+  sin traer los documentos.
 
 ---
 
 ## Checklist de implementación
 
-- [ ] Definir si el mapping género→slug vive en backend o se traduce en
-      frontend antes del render.
-- [ ] Implementar `getFeaturedBooks()` y `getTopGenres()`.
-- [ ] Implementar caché en memoria con TTL de 24h, entrada única.
-- [ ] Exponer `GET /api/home/highlights`.
+Backend (hecho, v3.4.0):
+
+- [x] Definir si el mapping género→slug vive en backend o se traduce en
+      frontend antes del render → **frontend**, ver arriba.
+- [x] Implementar `getFeaturedBooks()` y `getTopGenres()`
+      (`lib/homeHighlights.js`).
+- [x] Implementar caché en memoria con TTL de 24h, entrada única.
+- [x] Exponer `GET /home/highlights` (`routes/homeHighlights.js`, ruta
+      registrada en `lib/namedRoutes.js` + `routes/router.js`).
+- [x] Verificar índices de Mongo necesarios para ambas queries.
+- [x] Tests (`tests/homeHighlights.test.js`): forma de la respuesta,
+      argumentos de query y aggregate, proyección, autor borrado, hit de
+      caché, invalidación y error sin envenenar la caché.
+
+Frontend (pendiente):
+
 - [ ] Integrar en `getServerSideProps` de home con `Promise.all`.
-- [ ] Verificar índices de Mongo necesarios para ambas queries.
+- [ ] Traducir `code` → slug + nombre en español con `src/data/genres.ts`, y
+      comprobar que cubre los 17 códigos de `utils/constants/genres.js`.
 - [ ] Confirmar con `frontend-reviewer` que los componentes de UI
       (`FeaturedBooks`, `TopGenres`) siguen el sistema de diseño ya
       establecido (`sistema-diseno-resenan-sancho.md`).

--- a/docs/home-highlights-spec.md
+++ b/docs/home-highlights-spec.md
@@ -1,0 +1,176 @@
+# Home — Highlights (libros destacados + géneros top) · Especificación técnica
+
+Documento de referencia para implementar el endpoint que alimenta dos bloques
+de contenido en la home: **libros destacados** y **géneros más activos**.
+Complementa `home-hero-spec.md` (diseño visual) y se integra en el trabajo de
+S4 (home SSR + JSON-LD).
+
+---
+
+## Contexto y objetivo
+
+La home tiene poco contenido sustancial, lo cual es un problema doble:
+
+1. **SEO**: pocas señales semánticas de qué trata el sitio.
+2. **Producto**: no se están mostrando los servicios de promoción para
+   escritores ni la actividad real de la plataforma.
+
+Este endpoint resuelve el segundo bloque de contenido: una sección de
+"libros destacados" (con más ejemplares disponibles) y otra de "géneros más
+activos" (con más libros disponibles por género), enlazando a rutas ya
+existentes en producción.
+
+---
+
+## Endpoint
+
+### `GET /api/home/highlights`
+
+Devuelve ambos bloques en una sola respuesta, para evitar dos round-trips
+desde `getServerSideProps` de home.
+
+#### Response
+
+```json
+{
+  "featuredBooks": [
+    {
+      "id": "...",
+      "titulo": "...",
+      "autor": "...",
+      "genero": "novela-historica",
+      "ejemplaresDisponibles": 8,
+      "slug": "..."
+    }
+  ],
+  "topGenres": [
+    { "slug": "novela-historica", "nombre": "Novela histórica", "totalLibros": 142 },
+    { "slug": "poesia", "nombre": "Poesía", "totalLibros": 98 },
+    { "slug": "ensayo", "nombre": "Ensayo", "totalLibros": 76 }
+  ],
+  "cachedAt": "2026-08-15T10:00:00Z"
+}
+```
+
+- `featuredBooks`: top 4 libros ordenados por `ejemplaresDisponibles desc`.
+- `topGenres`: top 3 géneros ordenados por cantidad total de libros
+  disponibles en ese género.
+- `slug` en ambos bloques mapea directamente a rutas ya existentes en
+  producción:
+  - Libro → página de detalle (`/books/[id]`, SSR desde PR #64)
+  - Género → `/libros/genero/<slug>`
+- El mapping código interno → slug usa la tabla bidireccional ya definida en
+  `src/data/genres.ts`. A decidir con `senior-backend`: si el backend
+  mantiene su propia copia del mapping o si el frontend traduce el código
+  interno (`genero`) al slug antes de construir el link — según dónde viva
+  ya esa lógica en el código actual.
+
+---
+
+## Caché
+
+Dado que ninguno de los dos bloques cambia con frecuencia, y el dyno
+contratado es **Heroku Basic (single dyno)**, no hay problema de
+consistencia entre procesos: una caché en memoria del proceso Express es
+suficiente y evita añadir Redis o un documento de caché en Mongo.
+
+### Parámetros
+
+- **TTL: 24 horas** para ambos bloques (`featuredBooks` y `topGenres`).
+- **Una única entrada de caché**, no por-usuario ni por-request — ambos
+  bloques son iguales para todo el mundo. La home no debería tocar Mongo
+  salvo, como mucho, una vez al día.
+- **Sin invalidación activa** en esta v1.
+
+### Implementación de referencia
+
+```js
+let cache = { data: null, expiresAt: 0 };
+
+async function getHomeHighlights() {
+  const now = Date.now();
+  if (cache.data && now < cache.expiresAt) {
+    return cache.data;
+  }
+
+  const [featuredBooks, topGenres] = await Promise.all([
+    getFeaturedBooks(),
+    getTopGenres(),
+  ]);
+
+  cache.data = {
+    featuredBooks,
+    topGenres,
+    cachedAt: new Date().toISOString(),
+  };
+  cache.expiresAt = now + 24 * 60 * 60 * 1000;
+
+  return cache.data;
+}
+```
+
+### Notas
+
+- **Reinicio del dyno**: en Heroku Basic el dyno se recicla al menos una vez
+  al día (cycling) y en cada deploy, así que la caché en memoria se refresca
+  con esa cadencia natural. No hay riesgo real de quedarse con datos muy
+  desactualizados.
+- **Evolución futura**: si en algún momento las compras de servicios de
+  promoción (`boost25`, `featuredWeek`) deben afectar a `featuredBooks` en
+  tiempo real, se puede invalidar la caché puntualmente al confirmarse un
+  pago (`cache.expiresAt = 0`). No es necesario para esta v1 — de momento el
+  ranking de `featuredBooks` es puramente orgánico, por
+  `ejemplaresDisponibles`.
+- Si en el futuro se pasa a multi-dyno, esta caché en memoria dejaría de ser
+  válida (cada dyno tendría su propia copia, recalculando de forma
+  independiente al expirar su TTL) y habría que revisar la estrategia
+  (Mongo o Redis compartido). No aplica mientras el plan sea Basic.
+
+---
+
+## Integración en frontend
+
+En `getServerSideProps` de home:
+
+- Una sola llamada a `GET /api/home/highlights`, en paralelo con cualquier
+  otra data que ya se esté pidiendo en esa misma función (`Promise.all`).
+- En el peor caso (caché backend fría), el usuario que dispara el
+  recálculo paga el coste del aggregate — con un TTL de 24h esto es un
+  evento rarísimo y no justifica loading states especiales.
+- Los bloques de UI (`FeaturedBooks`, `TopGenres`) reciben los datos ya
+  resueltos vía props, sin fetch adicional en cliente.
+
+---
+
+## Queries de referencia (MongoDB)
+
+### `getFeaturedBooks()`
+
+Ordenar por `ejemplaresDisponibles` descendente, limitar a 4, proyectar solo
+los campos necesarios para la card (`titulo`, `autor`, `genero`,
+`ejemplaresDisponibles`, `slug`/`id`).
+
+### `getTopGenres()`
+
+Aggregate agrupando por `genero`, contando documentos, ordenando por conteo
+descendente, limitando a 3. Traducir el código interno de género a nombre
+en español (ya existente en `src/data/genres.ts`) y a slug para el link.
+
+Ambas queries son responsabilidad de `senior-backend` para definir los
+índices necesarios (por ejemplo, índice sobre `ejemplaresDisponibles` si no
+existe ya) antes de implementar.
+
+---
+
+## Checklist de implementación
+
+- [ ] Definir si el mapping género→slug vive en backend o se traduce en
+      frontend antes del render.
+- [ ] Implementar `getFeaturedBooks()` y `getTopGenres()`.
+- [ ] Implementar caché en memoria con TTL de 24h, entrada única.
+- [ ] Exponer `GET /api/home/highlights`.
+- [ ] Integrar en `getServerSideProps` de home con `Promise.all`.
+- [ ] Verificar índices de Mongo necesarios para ambas queries.
+- [ ] Confirmar con `frontend-reviewer` que los componentes de UI
+      (`FeaturedBooks`, `TopGenres`) siguen el sistema de diseño ya
+      establecido (`sistema-diseno-resenan-sancho.md`).

--- a/lib/homeHighlights.js
+++ b/lib/homeHighlights.js
@@ -1,0 +1,97 @@
+'use strict';
+const Book = require('../models/book');
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const FEATURED_BOOKS_LIMIT = 4;
+const TOP_GENRES_LIMIT = 3;
+
+// Both blocks only count books that still have copies to give away: a book with
+// copies: 0 is not orderable, so it should not be featured nor inflate a genre.
+const AVAILABLE = { copies: { $gt: 0 } };
+
+// Single cache entry, shared by every visitor (the home blocks are the same for
+// everyone). Valid while the app runs on a single dyno — see docs/home-highlights-spec.md.
+let cache = { data: null, expiresAt: 0 };
+// De-duplicates concurrent misses so a cold cache triggers one round of queries,
+// not one per in-flight request.
+let inFlight = null;
+
+// Top books by available copies. The author is flattened to a display string:
+// the card only needs a name, and this keeps the payload free of user internals.
+async function getFeaturedBooks() {
+  const books = await Book
+    .find(AVAILABLE)
+    .sort({ copies: -1, create_at: -1 })
+    .limit(FEATURED_BOOKS_LIMIT)
+    .select('title genre copies')
+    .populate('author', 'name lastName')
+    .lean();
+
+  return books.map((book) => ({
+    id: String(book._id),
+    title: book.title,
+    author: book.author ? `${book.author.name} ${book.author.lastName}`.trim() : null,
+    genre: book.genre,
+    copies: book.copies,
+  }));
+}
+
+// Genres with the most available books. `code` is the internal 3-letter genre
+// code (utils/constants/genres.js); the frontend translates it to the Spanish
+// label and the slug with the bidirectional table it already owns.
+async function getTopGenres() {
+  const genres = await Book.aggregate([
+    { $match: AVAILABLE },
+    { $group: { _id: '$genre', totalLibros: { $sum: 1 } } },
+    { $sort: { totalLibros: -1, _id: 1 } },
+    { $limit: TOP_GENRES_LIMIT },
+  ]);
+
+  return genres.map((genre) => ({
+    code: genre._id,
+    totalLibros: genre.totalLibros,
+  }));
+}
+
+async function buildHighlights() {
+  const [featuredBooks, topGenres] = await Promise.all([
+    getFeaturedBooks(),
+    getTopGenres(),
+  ]);
+
+  return {
+    featuredBooks,
+    topGenres,
+    cachedAt: new Date().toISOString(),
+  };
+}
+
+async function getHomeHighlights() {
+  if (cache.data && Date.now() < cache.expiresAt) {
+    return cache.data;
+  }
+  if (inFlight) {
+    return inFlight;
+  }
+
+  inFlight = buildHighlights()
+    .then((data) => {
+      cache = { data, expiresAt: Date.now() + TTL_MS };
+      return data;
+    })
+    .finally(() => {
+      // On failure nothing is cached, so the next request retries.
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+// Not used by the API in v1 (there is no active invalidation yet). Kept as the
+// hook for the future case described in the spec — invalidating on a confirmed
+// promotion payment — and used by the tests to start from a cold cache.
+function invalidateHomeHighlights() {
+  cache = { data: null, expiresAt: 0 };
+}
+
+module.exports = { getHomeHighlights, invalidateHomeHighlights };

--- a/lib/homeHighlights.js
+++ b/lib/homeHighlights.js
@@ -42,14 +42,14 @@ async function getFeaturedBooks() {
 async function getTopGenres() {
   const genres = await Book.aggregate([
     { $match: AVAILABLE },
-    { $group: { _id: '$genre', totalLibros: { $sum: 1 } } },
-    { $sort: { totalLibros: -1, _id: 1 } },
+    { $group: { _id: '$genre', totalBooks: { $sum: 1 } } },
+    { $sort: { totalBooks: -1, _id: 1 } },
     { $limit: TOP_GENRES_LIMIT },
   ]);
 
   return genres.map((genre) => ({
     code: genre._id,
-    totalLibros: genre.totalLibros,
+    totalBooks: genre.totalBooks,
   }));
 }
 

--- a/lib/namedRoutes.js
+++ b/lib/namedRoutes.js
@@ -3,6 +3,7 @@ module.exports = {
   'book': '/book',
   'deleteUser': '/deleteUser',
   'home': '/',
+  'homeHighlights': '/home/highlights',
   'login': '/login',
   'logout': '/logout',
   'orderBook': '/orderBook',

--- a/models/book.js
+++ b/models/book.js
@@ -58,4 +58,11 @@ const BookSchema = Schema({
   }],
 });
 
+// Serves the home "featured books" query: match copies > 0, sort by copies desc
+// (create_at only breaks ties, so the sort stays deterministic).
+BookSchema.index({ copies: -1, create_at: -1 });
+// Serves the home "top genres" aggregate: match copies > 0 and group by genre
+// straight from the index, without fetching the documents.
+BookSchema.index({ copies: 1, genre: 1 });
+
 module.exports = mongoose.model('book', BookSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "private": true,
   "engines": {
     "node": ">=22 <23"

--- a/routes/homeHighlights.js
+++ b/routes/homeHighlights.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const { getHomeHighlights } = require('../lib/homeHighlights');
+
+/* GET the home content blocks: featured books + most active genres. Public. */
+router.get('/', async function (req, res) {
+  try {
+    const highlights = await getHomeHighlights();
+    res.json(highlights);
+  } catch (error) {
+    console.log('error', error);
+    res.status(500).json({ message: 'No se han podido cargar los destacados de la home' });
+  }
+});
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -6,6 +6,7 @@ const bookRouter = require('./book');
 const booksRouter = require('./books');
 const deleteUserRouter = require('./deleteUser');
 const indexRouter = require('./index');
+const homeHighlightsRouter = require('./homeHighlights');
 const loginRouter = require('./login');
 const logoutRouter = require('./logout');
 const orderBookRouter = require('./orderBook');
@@ -28,6 +29,7 @@ class Router {
     app.use(namedRoutes.books, booksRouter);
     app.use(namedRoutes.deleteUser, deleteUserRouter);
     app.use(namedRoutes.home, indexRouter);
+    app.use(namedRoutes.homeHighlights, homeHighlightsRouter);
     app.use(namedRoutes.login, loginRouter);
     app.use(namedRoutes.logout, logoutRouter);
     app.use(namedRoutes.orderBook, orderBookRouter);

--- a/tests/homeHighlights.test.js
+++ b/tests/homeHighlights.test.js
@@ -38,7 +38,7 @@ describe('GET /home/highlights', () => {
     jest.clearAllMocks();
     invalidateHomeHighlights();
     mockFind([bookDoc()]);
-    Book.aggregate.mockResolvedValue([{ _id: 'HIF', totalLibros: 142 }]);
+    Book.aggregate.mockResolvedValue([{ _id: 'HIF', totalBooks: 142 }]);
   });
 
   test('returns both blocks with a cachedAt timestamp', async () => {
@@ -53,7 +53,7 @@ describe('GET /home/highlights', () => {
       genre: 'HIF',
       copies: 8,
     }]);
-    expect(res.body.topGenres).toEqual([{ code: 'HIF', totalLibros: 142 }]);
+    expect(res.body.topGenres).toEqual([{ code: 'HIF', totalBooks: 142 }]);
     expect(Date.parse(res.body.cachedAt)).not.toBeNaN();
   });
 
@@ -67,8 +67,8 @@ describe('GET /home/highlights', () => {
     expect(query.limit).toHaveBeenCalledWith(4);
     expect(Book.aggregate).toHaveBeenCalledWith([
       { $match: { copies: { $gt: 0 } } },
-      { $group: { _id: '$genre', totalLibros: { $sum: 1 } } },
-      { $sort: { totalLibros: -1, _id: 1 } },
+      { $group: { _id: '$genre', totalBooks: { $sum: 1 } } },
+      { $sort: { totalBooks: -1, _id: 1 } },
       { $limit: 3 },
     ]);
   });
@@ -117,9 +117,9 @@ describe('GET /home/highlights', () => {
     expect(res.body).toEqual({ message: 'No se han podido cargar los destacados de la home' });
 
     // A later request must retry instead of serving a poisoned cache.
-    Book.aggregate.mockResolvedValue([{ _id: 'POE', totalLibros: 5 }]);
+    Book.aggregate.mockResolvedValue([{ _id: 'POE', totalBooks: 5 }]);
     const retry = await request(app).get('/home/highlights');
     expect(retry.status).toBe(200);
-    expect(retry.body.topGenres).toEqual([{ code: 'POE', totalLibros: 5 }]);
+    expect(retry.body.topGenres).toEqual([{ code: 'POE', totalBooks: 5 }]);
   });
 });

--- a/tests/homeHighlights.test.js
+++ b/tests/homeHighlights.test.js
@@ -1,0 +1,125 @@
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../lib/connectMongoose', () => ({}));
+jest.mock('stripe', () => jest.fn(() => ({ paymentIntents: { create: jest.fn() } })));
+jest.mock('../models/book', () => require('./helpers/modelMock').makeModelMock(['find', 'aggregate']));
+
+const request = require('supertest');
+const Book = require('../models/book');
+const app = require('../app');
+const { invalidateHomeHighlights } = require('../lib/homeHighlights');
+
+// Book.find(...) is a chainable query in Mongoose; the mock mimics the chain and
+// resolves on the terminal .lean() call.
+const mockFind = (books) => {
+  const query = {
+    sort: jest.fn(() => query),
+    limit: jest.fn(() => query),
+    select: jest.fn(() => query),
+    populate: jest.fn(() => query),
+    lean: jest.fn().mockResolvedValue(books),
+  };
+  Book.find.mockReturnValue(query);
+  return query;
+};
+
+const bookDoc = (overrides = {}) => ({
+  _id: 'b1',
+  title: 'La sombra del viento',
+  genre: 'HIF',
+  copies: 8,
+  author: { name: 'Carlos', lastName: 'Zafón' },
+  ...overrides,
+});
+
+describe('GET /home/highlights', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    invalidateHomeHighlights();
+    mockFind([bookDoc()]);
+    Book.aggregate.mockResolvedValue([{ _id: 'HIF', totalLibros: 142 }]);
+  });
+
+  test('returns both blocks with a cachedAt timestamp', async () => {
+    const res = await request(app).get('/home/highlights');
+
+    expect(res.status).toBe(200);
+    expect(res.type).toMatch(/json/);
+    expect(res.body.featuredBooks).toEqual([{
+      id: 'b1',
+      title: 'La sombra del viento',
+      author: 'Carlos Zafón',
+      genre: 'HIF',
+      copies: 8,
+    }]);
+    expect(res.body.topGenres).toEqual([{ code: 'HIF', totalLibros: 142 }]);
+    expect(Date.parse(res.body.cachedAt)).not.toBeNaN();
+  });
+
+  test('only counts books with available copies, sorted by copies desc, limited to 4', async () => {
+    const query = mockFind([bookDoc()]);
+
+    await request(app).get('/home/highlights');
+
+    expect(Book.find).toHaveBeenCalledWith({ copies: { $gt: 0 } });
+    expect(query.sort).toHaveBeenCalledWith({ copies: -1, create_at: -1 });
+    expect(query.limit).toHaveBeenCalledWith(4);
+    expect(Book.aggregate).toHaveBeenCalledWith([
+      { $match: { copies: { $gt: 0 } } },
+      { $group: { _id: '$genre', totalLibros: { $sum: 1 } } },
+      { $sort: { totalLibros: -1, _id: 1 } },
+      { $limit: 3 },
+    ]);
+  });
+
+  test('does not expose author internals beyond the display name', async () => {
+    const query = mockFind([bookDoc()]);
+
+    await request(app).get('/home/highlights');
+
+    expect(query.select).toHaveBeenCalledWith('title genre copies');
+    expect(query.populate).toHaveBeenCalledWith('author', 'name lastName');
+  });
+
+  test('tolerates a book whose author no longer exists', async () => {
+    mockFind([bookDoc({ author: null })]);
+
+    const res = await request(app).get('/home/highlights');
+
+    expect(res.status).toBe(200);
+    expect(res.body.featuredBooks[0].author).toBeNull();
+  });
+
+  test('serves the cached payload without hitting the db again', async () => {
+    const first = await request(app).get('/home/highlights');
+    const second = await request(app).get('/home/highlights');
+
+    expect(Book.find).toHaveBeenCalledTimes(1);
+    expect(Book.aggregate).toHaveBeenCalledTimes(1);
+    expect(second.body).toEqual(first.body);
+  });
+
+  test('recomputes once the cache is invalidated', async () => {
+    await request(app).get('/home/highlights');
+    invalidateHomeHighlights();
+    await request(app).get('/home/highlights');
+
+    expect(Book.find).toHaveBeenCalledTimes(2);
+  });
+
+  test('responds 500 and caches nothing when a query fails', async () => {
+    Book.aggregate.mockRejectedValue(new Error('mongo down'));
+
+    const res = await request(app).get('/home/highlights');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ message: 'No se han podido cargar los destacados de la home' });
+
+    // A later request must retry instead of serving a poisoned cache.
+    Book.aggregate.mockResolvedValue([{ _id: 'POE', totalLibros: 5 }]);
+    const retry = await request(app).get('/home/highlights');
+    expect(retry.status).toBe(200);
+    expect(retry.body.topGenres).toEqual([{ code: 'POE', totalLibros: 5 }]);
+  });
+});


### PR DESCRIPTION
Implementa la parte de backend de `docs/home-highlights-spec.md`: un endpoint
que alimenta los dos bloques de contenido de la home (libros destacados y
géneros más activos) en una sola respuesta.

## Endpoint

`GET /home/highlights` — público, sin `verifyToken()`.

```json
{
  "featuredBooks": [
    { "id": "...", "title": "...", "author": "Carlos Zafón", "genre": "HIF", "copies": 8 }
  ],
  "topGenres": [
    { "code": "HIF", "totalBooks": 142 }
  ],
  "cachedAt": "2026-08-15T10:00:00Z"
}
```

## Decisiones tomadas sobre el spec

El documento dejaba tres puntos abiertos o desalineados con el código real:

- **Mapping género → slug/nombre: lo resuelve el frontend.** El backend
  devuelve el código interno de 3 letras (`utils/constants/genres.js`) y el
  frontend lo traduce con la tabla bidireccional que ya tiene en
  `src/data/genres.ts`. Una sola fuente de verdad; el backend no duplica datos
  de presentación.
- **Path sin prefijo `/api`.** El backend monta todo en la raíz (`/books`,
  `/login`, `/version`); el `/api` del spec es el rewrite de Next.
- **Claves en inglés.** El spec usaba `titulo` / `autor` /
  `ejemplaresDisponibles` / `genero`, campos que no existen: el modelo usa
  `title` / `author` / `copies` / `genre`. La respuesta sigue la convención del
  resto de endpoints.

Ambos bloques cuentan sólo libros con `copies > 0` — mismo criterio de
disponibilidad que `routes/books.js`. `copies` es el contador de ejemplares
disponibles: `routes/orderBook.js` lo decrementa con `$inc` en cada solicitud.

## Caché

Entrada única en memoria con TTL de 24h (`lib/homeHighlights.js`), como
describe el spec. Dos matices añadidos al implementarla:

- **De-duplicación de misses concurrentes**: se guarda la promesa en vuelo, así
  una caché fría (arranque de dyno) dispara una sola ronda de queries y no una
  por request simultánea.
- **Los errores no se cachean**: si una query falla no se guarda nada y el
  siguiente request reintenta. La ruta responde `500` con mensaje en español.

Sin invalidación activa en esta v1; `invalidateHomeHighlights()` queda como
gancho para el caso futuro (invalidar al confirmarse un pago de promoción).

## Índices

No había índice ni sobre `copies` ni sobre `genre`. Se añaden dos en
`models/book.js`: `{ copies: -1, create_at: -1 }` para el sort de destacados y
`{ copies: 1, genre: 1 }` para que el aggregate agrupe desde el índice.

## Tests

`tests/homeHighlights.test.js`, 7 casos: forma de la respuesta, argumentos de
query y aggregate, proyección, libro con autor borrado, hit de caché,
invalidación, y error sin envenenar la caché. Suite completa en verde (48
tests / 13 suites) y lint limpio.

## Pendiente (frontend, fuera de scope)

Integración en `getServerSideProps`, componentes `FeaturedBooks` / `TopGenres`,
y la traducción `code` → slug. **Ojo**: hay 17 códigos en
`utils/constants/genres.js` y conviene comprobar que `src/data/genres.ts` los
cubre todos — los ejemplos del spec (`ensayo`, `novela-historica`) no
corresponden uno a uno con ellos.

Versión: 3.3.1 → **3.4.0** (MINOR: endpoint nuevo, sin breaking changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
