### PR TITLE
Add cover to home highlights featured books

### DIFF
--- a/docs/home-highlights-spec.md
+++ b/docs/home-highlights-spec.md
@@ -43,7 +43,8 @@ desde `getServerSideProps` de home. Público, sin `verifyToken()`.
       "title": "...",
       "author": "Carlos Zafón",
       "genre": "HIF",
-      "copies": 8
+      "copies": 8,
+      "cover": "https://.../portada.jpg"
     }
   ],
   "topGenres": [
@@ -66,6 +67,9 @@ Las claves van en inglés, como el modelo y el resto de endpoints (`/books`).
   mismo criterio de disponibilidad que ya usa `routes/books.js`.
 - `author` viene aplanado a un string de display (`name + lastName`); la card
   sólo necesita un nombre y así no se filtran internos del usuario.
+- `cover` es la URL de la portada tal cual está en el modelo (`cover` es
+  `required`, así que siempre viene). La card la necesita para renderizar la
+  imagen sin un fetch extra por libro.
 - El libro no tiene `slug` en el modelo, y el destino del link es
   `/books/[id]` (SSR desde PR #64), así que se devuelve `id` a secas.
 
@@ -164,7 +168,7 @@ el número de ejemplares disponibles: `routes/orderBook.js` lo decrementa con
 Book.find({ copies: { $gt: 0 } })
   .sort({ copies: -1, create_at: -1 })
   .limit(4)
-  .select('title genre copies')
+  .select('title genre copies cover')
   .populate('author', 'name lastName')
   .lean();
 ```

--- a/lib/homeHighlights.js
+++ b/lib/homeHighlights.js
@@ -23,7 +23,7 @@ async function getFeaturedBooks() {
     .find(AVAILABLE)
     .sort({ copies: -1, create_at: -1 })
     .limit(FEATURED_BOOKS_LIMIT)
-    .select('title genre copies')
+    .select('title genre copies cover')
     .populate('author', 'name lastName')
     .lean();
 
@@ -33,6 +33,7 @@ async function getFeaturedBooks() {
     author: book.author ? `${book.author.name} ${book.author.lastName}`.trim() : null,
     genre: book.genre,
     copies: book.copies,
+    cover: book.cover,
   }));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "private": true,
   "engines": {
     "node": ">=22 <23"

--- a/tests/homeHighlights.test.js
+++ b/tests/homeHighlights.test.js
@@ -29,6 +29,7 @@ const bookDoc = (overrides = {}) => ({
   title: 'La sombra del viento',
   genre: 'HIF',
   copies: 8,
+  cover: 'https://cdn.resenansancho.com/covers/b1.jpg',
   author: { name: 'Carlos', lastName: 'Zafón' },
   ...overrides,
 });
@@ -52,6 +53,7 @@ describe('GET /home/highlights', () => {
       author: 'Carlos Zafón',
       genre: 'HIF',
       copies: 8,
+      cover: 'https://cdn.resenansancho.com/covers/b1.jpg',
     }]);
     expect(res.body.topGenres).toEqual([{ code: 'HIF', totalBooks: 142 }]);
     expect(Date.parse(res.body.cachedAt)).not.toBeNaN();
@@ -78,7 +80,7 @@ describe('GET /home/highlights', () => {
 
     await request(app).get('/home/highlights');
 
-    expect(query.select).toHaveBeenCalledWith('title genre copies');
+    expect(query.select).toHaveBeenCalledWith('title genre copies cover');
     expect(query.populate).toHaveBeenCalledWith('author', 'name lastName');
   });
 


### PR DESCRIPTION
## Qué cambia

`GET /home/highlights` devuelve ahora `cover` (URL de la portada) en cada
elemento de `featuredBooks`, para que las cards de la home puedan renderizar la
imagen sin un fetch extra por libro.

```json
{
  "id": "...",
  "title": "...",
  "author": "Carlos Zafón",
  "genre": "HIF",
  "copies": 8,
  "cover": "https://.../portada.jpg"
}
```

- `lib/homeHighlights.js`: `cover` añadido a la proyección (`.select`) y al
  objeto mapeado. Sin fallback: `cover` es `required: true` en `models/book.js`.
- `tests/homeHighlights.test.js`: fixture con portada, aserción de forma de la
  respuesta y de la proyección actualizadas.
- `docs/home-highlights-spec.md`: ejemplo de respuesta, notas de campos y
  snippet de la query al día con lo implementado.

## Versión

`3.4.0` → `3.5.0` (MINOR: campo nuevo, aditivo y no rompe el contrato; 3.4.0 ya
está en producción).

## Tests

Suite completa en verde: 48/48. `npm run lint` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)