### PR TITLE
Publicación automática en Instagram al dar de alta un libro

### DIFF
--- a/.claude/agent-memory/backend-node-reviewer/MEMORY.md
+++ b/.claude/agent-memory/backend-node-reviewer/MEMORY.md
@@ -1,0 +1,4 @@
+- [API response shape](api-response-shape.md) — endpoints return `{ success, message }` JSON; errors swallowed to 200 in some routes
+- [Mongoose upgrade migration](mongoose-upgrade.md) — incremental 5→6→7→8→9 dependency upgrade on feature branches, phased
+- [Model registration names](model-names.md) — model names are lowercase singular: `user`, `book`, `reviewer`
+- [Mailchimp fetch semantics](mailchimp-fetch-semantics.md) — 400=success in 2 files; fetch doesn't throw on non-2xx; never persist numeric body.status

--- a/.claude/agent-memory/backend-node-reviewer/api-response-shape.md
+++ b/.claude/agent-memory/backend-node-reviewer/api-response-shape.md
@@ -1,0 +1,12 @@
+---
+name: api-response-shape
+description: Standard API response shape and error-handling pattern in this Express backend
+metadata:
+  type: project
+---
+
+Routes return JSON of shape `{ success: boolean, message: string }` (sometimes with extra data fields).
+
+Error handling in route handlers tends to respond with HTTP 200 + `{ success: false, message }` rather than proper 4xx/5xx status codes, and several handlers both send a response AND call `next(err)` in the catch block (double-handling risk).
+
+**How to apply:** When reviewing routes, flag missing status codes (auth failures should be 401/403, not-found 404) but recognize the existing `{ success, message }` convention is established — suggest status codes as warnings, not as inconsistency with project style. Watch for the `res.json(...)` followed by `next(err)` double-response anti-pattern.

--- a/.claude/agent-memory/backend-node-reviewer/mailchimp-fetch-semantics.md
+++ b/.claude/agent-memory/backend-node-reviewer/mailchimp-fetch-semantics.md
@@ -1,0 +1,18 @@
+---
+name: mailchimp-fetch-semantics
+description: Mailchimp integration conventions and the fetch (vs superagent) non-2xx trap in the 4 Mailchimp route files
+metadata:
+  type: project
+---
+
+Mailchimp is called from 4 route files: `routes/login.js`, `routes/suscribeAuthor.js`, `routes/deleteUser.js`, `routes/registerReviewer.js`. Auth is `Basic base64('anystring:' + MAIL_CHIMP_API_KEY)`.
+
+Conventions to preserve:
+- **HTTP 400 is treated as SUCCESS** in `suscribeAuthor.js` and `deleteUser.js` (Mailchimp returns 400 for "already a member"). Check pattern: `status < 300 || status === 400`. Note: `registerReviewer.js` POST/PUT do NOT follow this (they use only `>= 200 && < 300`) — a pre-existing inconsistency.
+
+fetch migration trap (Node 22 global fetch replaced superagent):
+- **fetch does NOT throw on non-2xx**; superagent did. Any place that previously relied on a GET throwing (e.g. a 404 for a non-existent member jumping to catch) will now fall through.
+- **On a non-2xx Mailchimp response the JSON body's `status` field is a numeric HTTP code** (e.g. 404), NOT a subscription string. Never persist or forward `body.status`/`member.status` without an `.ok` guard. `registerReviewer.js` PUT was flagged for exactly this: it reads `member.status` from a GET that can 404 and puts it back as the subscription status.
+- `login.js` does this correctly: try/catch + `if (response.ok)` before reading `response.json()`, so login is never blocked and no numeric status leaks.
+
+**How to apply:** When reviewing any fetch call against Mailchimp, verify `.ok`/status is checked before reading a field out of the body, and confirm the 400-as-success semantic is preserved where it applies. See [[api-response-shape]] for the broader "200 + {success:false}" and raw-error-leak (`res.json(error)`) patterns in these same handlers.

--- a/.claude/agent-memory/backend-node-reviewer/model-names.md
+++ b/.claude/agent-memory/backend-node-reviewer/model-names.md
@@ -1,0 +1,10 @@
+---
+name: model-names
+description: Mongoose model registration names used in this project
+metadata:
+  type: project
+---
+
+Models are registered with lowercase singular names: `mongoose.model('user', ...)`, `mongoose.model('book', ...)`, `mongoose.model('reviewer', ...)`. Cross-model references in hooks use these exact strings (e.g. `this.model('book')`).
+
+**How to apply:** When reviewing `this.model('x')` or `.populate()`/ref usage, verify the string matches these lowercase singular names.

--- a/.claude/agent-memory/backend-node-reviewer/mongoose-upgrade.md
+++ b/.claude/agent-memory/backend-node-reviewer/mongoose-upgrade.md
@@ -1,0 +1,14 @@
+---
+name: mongoose-upgrade
+description: Incremental Mongoose dependency upgrade (5 to 9) being done in phases on feature branches
+metadata:
+  type: project
+---
+
+The team is upgrading Mongoose incrementally: 5→6→7 done by Phase 5 (branch `feature/mongoose-upgrade`), with 8→9 still to come in later phases. Stripe/Nodemailer/Mailchimp/superagent modernization is deferred to a later "Phase 7".
+
+Key migration patterns applied: `pre('remove')` document hook → `pre('deleteOne', { document: true, query: false })`; `userDoc.remove()` → `userDoc.deleteOne()`; removed `useNewUrlParser`/`useCreateIndex` connect options; set `strictQuery` explicitly.
+
+**Why:** Node engine pinned to `>=22 <23`; modern Mongoose required for support.
+
+**How to apply:** During this migration, do NOT flag the superagent/Mailchimp callback flow as needing rewrite (deferred to Phase 7) — but DO flag genuine bugs in it. Focus review on Mongoose/Express correctness.

--- a/.claude/agents/backend-node-reviewer.md
+++ b/.claude/agents/backend-node-reviewer.md
@@ -1,0 +1,200 @@
+---
+name: "backend-node-reviewer"
+description: "Use this agent when you have written or modified backend Node.js code and are about to commit it. This agent specializes in reviewing Express routes, MongoDB/Mongoose models and queries, Stripe payment integrations, and JWT authentication logic to catch inconsistencies, bad practices, probable bugs, and to suggest maintainability and readability improvements. It reviews recently changed code by default, not the entire codebase.\\n\\n<example>\\nContext: The user just finished implementing a new Express endpoint that creates a Stripe charge and saves an order via Mongoose.\\nuser: \"I've added the POST /orders endpoint that charges the customer with Stripe and saves the order. I think I'm ready to commit.\"\\nassistant: \"Before you commit, let me use the Agent tool to launch the backend-node-reviewer agent to review the new endpoint for inconsistencies, bad practices, and potential bugs.\"\\n<commentary>\\nSince the user has written backend code and intends to commit, use the backend-node-reviewer agent to review the recently changed code before the commit happens.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user modified the JWT authentication middleware and a Mongoose user model.\\nuser: \"Updated the auth middleware to refresh tokens and tweaked the User schema. Going to commit now.\"\\nassistant: \"I'll use the Agent tool to launch the backend-node-reviewer agent first to review the auth middleware and schema changes for security issues and probable bugs before you commit.\"\\n<commentary>\\nAuthentication and schema changes are exactly the kind of backend code this agent should review prior to a commit, so launch the backend-node-reviewer agent.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user runs git add and asks to commit.\\nuser: \"git commit -m 'add subscription billing logic'\"\\nassistant: \"Before committing the subscription billing logic, let me use the Agent tool to launch the backend-node-reviewer agent to review the staged changes for Stripe and data-consistency issues.\"\\n<commentary>\\nThe user is about to commit backend changes; proactively use the backend-node-reviewer agent to review prior to the commit.\\n</commentary>\\n</example>"
+tools: Agent, Bash, CronCreate, CronDelete, CronList, DesignSync, Edit, EnterWorktree, ExitWorktree, Monitor, NotebookEdit, PushNotification, Read, RemoteTrigger, Skill, TaskCreate, TaskGet, TaskList, TaskStop, TaskUpdate, ToolSearch, WebFetch, WebSearch, Write
+model: opus
+color: red
+memory: project
+---
+
+You are a Senior Backend Engineer and Code Review Specialist with deep, hands-on expertise in Node.js, Express, MongoDB, Mongoose, the Stripe API, and jsonwebtoken (JWT). You have shipped and maintained production payment systems, authentication flows, and high-throughput APIs. Your reviews are precise, pragmatic, and respected because they catch real problems while improving long-term code health.
+
+You are invoked immediately before code is committed. Your job is to review the RECENTLY CHANGED code (staged/modified files and the diff), not the entire codebase, unless explicitly told otherwise. If you are unsure what changed, inspect the git diff (e.g., `git diff`, `git diff --staged`, and recently modified files) to scope your review.
+
+## Your Review Methodology
+
+1. **Establish scope**: Identify exactly which files and hunks changed. Focus your analysis there, but read enough surrounding context to understand intent and side effects.
+2. **Understand intent**: Infer what the change is trying to accomplish before judging it. Review against that goal.
+3. **Analyze systematically** across these dimensions:
+   - **Correctness & probable bugs**: off-by-one errors, missing `await`, unhandled promise rejections, incorrect conditionals, mutation of shared state, wrong status codes, race conditions.
+   - **Inconsistencies**: code that contradicts patterns elsewhere in the diff or established project conventions (naming, error handling, response shapes).
+   - **Bad practices**: callback/promise mixing, swallowed errors, console.log in production paths, hardcoded secrets, magic numbers, business logic in route handlers.
+   - **Maintainability & readability**: function length, naming clarity, duplication, missing abstraction, unclear control flow.
+
+4. **Apply domain-specific scrutiny**:
+   - **Express**: Ensure async route handlers wrap errors (try/catch or an async wrapper) so they reach error middleware; verify correct HTTP status codes and consistent response shapes; check middleware ordering; validate and sanitize all inputs (params, query, body); avoid leaking stack traces or internal errors to clients; confirm `next(err)` is used appropriately.
+   - **MongoDB & Mongoose**: Look for missing indexes on frequently queried fields, N+1 query patterns, unbounded queries without pagination/limits, missing `lean()` for read-only paths, improper use of `findOneAndUpdate` options, missing schema validation, lack of transactions where multi-document atomicity is required, and injection risks from unsanitized query objects. Check that `null`/not-found results are handled before dereferencing.
+   - **Stripe**: Verify idempotency keys on charge/payment-creating requests, correct webhook signature verification, handling of asynchronous payment states (do not assume success synchronously), proper currency/amount handling (integer minor units, never floats), graceful handling of Stripe errors and retries, and that secrets/keys come from environment variables. Watch for the dangerous pattern of charging before persisting (or persisting before confirming) without compensating logic.
+   - **JWT (jsonwebtoken)**: Confirm tokens are verified with an explicit algorithm (avoid `alg: none` and algorithm confusion), secrets are strong and env-sourced, expiration (`exp`) is set and checked, sensitive data is not stored in token payloads, and `jwt.verify` errors are caught. Check token storage/transport assumptions.
+   - **Security cross-cutting**: no secrets in code, proper input validation, no SQL/NoSQL injection vectors, no sensitive data in logs.
+
+5. **Self-verify before reporting**: For each finding, confirm it is actually present in the changed code, that your suggested fix is correct, and that you are not flagging style preferences as bugs. Distinguish clearly between must-fix issues and optional improvements.
+
+## Output Format
+
+Structure your review as follows:
+
+**Summary**: 1-3 sentences on overall quality and whether it is safe to commit.
+
+**Critical Issues (must fix before commit)**: Numbered list. For each: file:line reference, what is wrong, why it matters, and a concrete suggested fix (with a short code snippet when helpful).
+
+**Warnings (should fix)**: Bad practices and probable bugs that are not blockers but matter.
+
+**Suggestions (maintainability & readability)**: Optional improvements that raise code quality.
+
+**Positive Notes**: Briefly acknowledge well-done aspects to reinforce good patterns.
+
+If there are no issues in a category, state that explicitly rather than omitting it. Prioritize the highest-impact findings first. Be specific: always cite file and line/function, and prefer showing the corrected code over describing it abstractly.
+
+## Operating Principles
+- Be direct and constructive; critique the code, not the author.
+- Do not rewrite the entire file; suggest targeted changes.
+- If the change is small and clean, say so and keep the review proportionate.
+- If you lack context to judge correctness (e.g., you cannot see a referenced function), ask a focused clarifying question or state the assumption you are making.
+- Never approve code with leaked secrets, missing payment idempotency, unverified JWTs, or unhandled async errors without flagging them as critical.
+
+**Update your agent memory** as you discover project-specific conventions and recurring issues. This builds up institutional knowledge across conversations so your future reviews are faster and more consistent. Write concise notes about what you found and where.
+
+Examples of what to record:
+- Project conventions: standard API response shape, error-handling patterns (e.g., async wrapper utility location), naming conventions for models/routes/services.
+- Architectural decisions: where Stripe logic lives, how JWT auth middleware is structured, transaction usage patterns, Mongoose schema conventions.
+- Recurring issues: repeated bad practices or bug patterns this team tends to introduce, so you can flag them proactively.
+- Domain specifics: required env variable names, idempotency-key conventions, webhook handling locations, indexing decisions on key collections.
+
+# Persistent Agent Memory
+
+You have a persistent, file-based memory system at `/Users/alejandrocapparelli/Documents/KeepCoding/resenan_sancho/backend/.claude/agent-memory/backend-node-reviewer/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in CLAUDE.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{short-kebab-case-slug}}
+description: {{one-line summary — used to decide relevance in future conversations, so be specific}}
+metadata:
+  type: {{user, feedback, project, reference}}
+---
+
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines. Link related memories with [[their-name]].}}
+```
+
+In the body, link to related memories with `[[name]]`, where `name` is the other memory's `name:` slug. Link liberally — a `[[name]]` that doesn't match an existing memory yet is fine; it marks something worth writing later, not an error.
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
+
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you save new memories, they will appear here.

--- a/.claude/skills/test-before-commit/SKILL.md
+++ b/.claude/skills/test-before-commit/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: test-before-commit
+description: Backend skill that enforces running the unit test suite before every commit. Use this in the backend repo whenever you are about to commit changes (you have staged work and are running `git commit`). Run `npm run test` first; if any test fails, diagnose and fix the application code until the whole suite passes, then commit. NEVER commit with failing tests. If a test itself appears outdated or no longer valid (the code change is correct and the test encodes an obsolete expectation), do NOT modify or delete the test on your own initiative — stop and ask the user first.
+---
+
+# Test Before Commit (backend)
+
+Every commit in the backend must be made on top of a green test suite. This skill
+runs the unit tests before committing, fixes the code if they fail, and protects
+the tests from being silently changed.
+
+## When this applies
+
+- Apply this **before any commit** in the backend repo — whether it's the first
+  commit of a task or one of many while iterating.
+- It runs **after** you've made and staged your changes, as the last gate before
+  `git commit`.
+- It complements `git-workflow` (branch naming, commit message rules); it does not
+  replace it. Branch first per `git-workflow`, do the work, then run this gate
+  before each commit.
+
+## Workflow
+
+### 1. Run the unit tests
+
+From the backend project root:
+
+```bash
+npm run test
+```
+
+Wait for the full run to finish and read the output. Do not commit until you have
+seen the result.
+
+### 2a. If all tests pass
+
+Proceed to commit following the `git-workflow` message rules (imperative subject,
+≤100 chars). Done.
+
+### 2b. If one or more tests fail
+
+The default assumption is that **your code change is wrong, not the test**. Do the
+following:
+
+1. Read the failing test(s) and the assertion that failed. Understand what
+   behaviour the test expects.
+2. Inspect the application code you changed and find why it no longer satisfies
+   that expectation.
+3. **Fix the application code** so the behaviour is correct and the test passes.
+   Keep the fix focused on the actual cause — don't paper over it.
+4. Re-run `npm run test` and confirm the **whole** suite is green again (not just
+   the test you were looking at — a fix can break something else).
+5. Only then commit.
+
+Repeat until `npm run test` passes with no errors.
+
+### 3. Never commit red
+
+Do not commit while any test is failing. Do not skip, comment out, mark as
+`.skip`/`.only`, or otherwise neutralise a failing test to get a green run. A
+disabled test is a failing test in disguise.
+
+## When a test itself might be wrong
+
+Sometimes a test fails not because the code is broken but because the test encodes
+an expectation that is no longer valid (the requirement changed, the old behaviour
+was itself a bug, an API contract was intentionally updated, etc.).
+
+In that case:
+
+- **Do NOT modify, rewrite, or delete the test on your own initiative.**
+- Stop and ask the user first. Explain clearly:
+  - which test is failing,
+  - what it currently expects,
+  - why you believe that expectation is no longer valid,
+  - what change to the test you would propose.
+- Wait for explicit confirmation before touching the test.
+
+Only once the user confirms do you update the test, then re-run `npm run test` to
+confirm the suite is green, and commit.
+
+> The reason for asking first: a failing test is the project's early-warning system.
+> Editing a test to make it pass can silently erase a real regression. The judgement
+> call about whether a test is obsolete belongs to the user, not to you.
+
+## Quick checklist
+
+- [ ] Changes staged.
+- [ ] `npm run test` run and output read.
+- [ ] If failures and code is at fault → fixed the code, re-ran, suite green.
+- [ ] If failures and the *test* seems obsolete → asked the user, did not touch the
+      test unilaterally.
+- [ ] No tests skipped, disabled, or commented out to force green.
+- [ ] Only committed once the full suite passed.

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,4 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/node,macos,linux,windows
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,15 @@ There is no build step. The seed script refuses to run unless `MONGOOSE_CONNECTI
 **Integrations** (all keyed off env vars):
 - **Stripe** (`routes/paymentCheckout.js`) — `paymentIntents.create` to charge for promotion copies. The client pins `apiVersion` and the charge sets `automatic_payment_methods: { enabled: true, allow_redirects: 'never' }` (server-side card charge, no redirect flow — required by the current API when `confirm: true`).
 - **Nodemailer** (`lib/email.js`) — exports a shared `transporter` plus HTML template builders (password reset, book-copy request, promo confirmations). Used by routes like `registerBook`, `paymentCheckout`, `orderBook`.
+- **Instagram autopost** (`lib/instagram/`) — after a book is created, `publishToInstagram(book)` is fired **without await** from `routes/registerBook.js`: it renders a branded JPEG with `@napi-rs/canvas`, uploads it to Cloudinary and posts it through the Meta Graph API. Every env var (`SOCIAL_AUTOPOST_ENABLED`, `IG_DRY_RUN`, …) is read at call time, never at boot. Failures are logged and swallowed — they must never affect the response. See `README.md` and `docs/instagram-autopost-spec.md`.
 - **Mailchimp** (`routes/login.js`, `registerReviewer.js`, `suscribeAuthor.js`, `deleteUser.js`) — syncs email subscription status via the Mailchimp REST API using the built-in **`fetch`** (no HTTP client dependency). Mailchimp returns HTTP **400** for an already-existing member, which the code treats as success; on a non-2xx response the JSON body's `status` is a numeric HTTP code (not a subscription string), so guard on `response.ok` before reading it.
 
 ## Environment
 
 Requires a `.env` file (loaded by `dotenv` in `lib/connectMongoose.js`). Variables in use:
-`MONGOOSE_CONNECTION_STRING`, `PORT`, `FRONTEND_URL`, `JWT_SECRET`, `STRIPE_SECRET`, `MAIL_HOST`, `MAIL_PORT`, `MAIL_USER`, `MAIL_PASSWORD`, `MAIL_CHIMP_INSTANCE`, `MAIL_CHIMP_API_KEY`, `LIST_UNIQUE_ID`, `WRITERS_LIST_UNIQUE_ID`.
+`MONGOOSE_CONNECTION_STRING`, `PORT`, `FRONTEND_URL`, `JWT_SECRET`, `STRIPE_SECRET`, `MAIL_HOST`, `MAIL_PORT`, `MAIL_USER`, `MAIL_PASSWORD`, `MAIL_CHIMP_INSTANCE`, `MAIL_CHIMP_API_KEY`, `LIST_UNIQUE_ID`, `WRITERS_LIST_UNIQUE_ID`,
+`SOCIAL_AUTOPOST_ENABLED`, `IG_DRY_RUN`, `IG_PAGE_ACCESS_TOKEN`, `IG_BUSINESS_ACCOUNT_ID`,
+`CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,57 @@ npm start     # start the server (defaults to port 9000)
 npm test      # run the test suite
 ```
 
+## Instagram autopost
+
+When a book is created, the backend publishes a branded 1080x1350 image plus a
+Spanish caption on the official Instagram account. It runs after the response is
+sent, so it never delays nor breaks the book creation, and any failure is only
+logged (prefix `[instagram-autopost]`). Full spec:
+`docs/instagram-autopost-spec.md`.
+
+### Environment variables
+
+| Variable | Default | What it does |
+|---|---|---|
+| `SOCIAL_AUTOPOST_ENABLED` | `false` | Master switch. With `false` the feature does nothing. |
+| `IG_DRY_RUN` | `true` | See below. `false` = really publish. |
+| `IG_PAGE_ACCESS_TOKEN` | — | Long-lived page access token (secret). |
+| `IG_BUSINESS_ACCOUNT_ID` | — | Instagram business account id (`ig-user-id`), not the `@handle`. |
+| `CLOUDINARY_CLOUD_NAME` / `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` | — | Used to upload the generated image to the `instagram-posts/` folder; the Graph API needs a public URL. |
+
+All of them are read at publish time, not at boot, so the feature can be turned
+off or moved out of dry-run by changing a config var — no redeploy needed.
+
+### Dry run
+
+`IG_DRY_RUN=true` (the default, and what you want locally) exercises the whole
+pipeline except the external calls: the image is generated and the caption is
+built, but **nothing** is uploaded to Cloudinary and **no** Graph API call is
+made. The image is written to:
+
+```
+tmp/ig-preview-<bookId>-<timestamp>.jpg
+```
+
+and the caption, that path and the `ig-user-id` that would have been used are
+printed to the console. `instagramPostedAt` is **not** set, because nothing was
+really published. In production (Heroku) the variable is `false`.
+
+To review the layout without creating a book, render a sample straight into
+`tmp/`:
+
+```bash
+node scripts/instagramPreview.js                 # sample book
+node scripts/instagramPreview.js "Otro título" https://url/de/portada.jpg
+```
+
+### Fonts
+
+The image is composited with `@napi-rs/canvas`, which ships no fonts: it falls
+back to generic system faces (serif for the title, sans for the rest). Dropping
+the brand `.ttf`/`.otf` files (Fraunces, Source Sans 3) into `assets/fonts/`
+registers them automatically — no code change needed.
+
 # Scripts
 
 ## Seed

--- a/docs/instagram-autopost-spec.md
+++ b/docs/instagram-autopost-spec.md
@@ -1,0 +1,255 @@
+# Spec: publicación automática en Instagram al dar de alta un libro
+
+**Estado:** listo para implementación
+**Agente destino:** `senior-backend`
+**Repos afectados:** backend (Express/Mongoose)
+**Supersede:** cualquier nota anterior sobre este tema en otros ficheros de spec.
+
+---
+
+## 1. Objetivo
+
+Cuando se crea un libro nuevo en la plataforma, publicar automáticamente en la
+cuenta oficial de Instagram de Reseñan Sancho una imagen de marca con los
+datos del libro y un caption con la sinopsis, invitando a pedir un ejemplar.
+
+## 2. Decisiones ya tomadas (no reabrir sin motivo)
+
+- **Disparador:** solo en la **creación** del libro, no en cada edición. La
+  portada y la sinopsis ya son obligatorias para dar de alta un libro, así que
+  no hace falta comprobar "si está completo": siempre lo está en el momento
+  de creación.
+- **No bloqueante:** la petición de creación del libro responde al cliente
+  igual que hoy; la publicación en Instagram ocurre después, de forma
+  asíncrona, y cualquier fallo se registra pero nunca rompe ni retrasa la
+  respuesta al usuario.
+- **Sin reintentos automáticos en esta primera versión.** Si algo falla, se
+  loguea con detalle y se deja constancia; no hay cola de reintentos todavía
+  (se puede añadir más adelante si el fallo resulta frecuente en la práctica).
+- **Sin hashtags** en el caption, por decisión explícita.
+- **Generación de imagen server-side** con `@napi-rs/canvas` (no `node-canvas`)
+  para evitar la compilación nativa de Cairo en Heroku. Esta dependencia ya
+  está acordada; no hace falta volver a justificarla, pero sí añadirla al
+  `package.json` con su versión fijada.
+
+## 3. Variables de entorno
+
+Ya configuradas como config vars en Heroku (backend):
+
+| Variable | Valor / origen | Notas |
+|---|---|---|
+| `IG_PAGE_ACCESS_TOKEN` | Token de página de larga duración obtenido vía Graph API Explorer | No caduca por fecha, pero puede invalidarse (cambio de contraseña, revocación, revisión de seguridad de Meta). Tratarlo como secreto. |
+| `IG_BUSINESS_ACCOUNT_ID` | `17841405744435526` | ID de la cuenta de Instagram (ig-user-id), no el `@usuario`. |
+| `IG_DRY_RUN` | `true` en local, `false` en producción | Ver sección 7. |
+| `SOCIAL_AUTOPOST_ENABLED` | `true` / `false` | Flag general de la feature. Léase en runtime vía `process.env` en el backend — **nunca** como variable `NEXT_PUBLIC_*`, que se compila en build time y no reacciona a cambios de config var sin redeploy. |
+
+Todas se leen server-side, en el momento de intentar publicar — no en el
+arranque del proceso, para poder desactivar la feature sin redeploy.
+
+## 4. Cambios en el modelo `Book`
+
+Añadir un campo para evitar publicaciones duplicadas y dejar constancia de lo
+publicado:
+
+```js
+instagramPostedAt: {
+  type: Date,
+  default: null,
+}
+```
+
+Antes de intentar publicar, comprobar que `instagramPostedAt` es `null`. Tras
+una publicación real con éxito (no en dry-run), setear la fecha actual.
+
+## 5. Flujo general
+
+```
+POST /books (creación)
+  → guarda el libro en Mongo
+  → responde al cliente (sin esperar a Instagram)
+  → dispara publishToInstagram(book) sin await, envuelto en try/catch
+       1. generar imagen de marca (canvas)
+       2. construir el caption
+       3. [modo real] subir imagen a Cloudinary
+       4. [modo real] crear contenedor de medios en Graph API
+       5. [modo real] esperar a que el contenedor esté FINISHED
+       6. [modo real] publicar el contenedor
+       7. marcar book.instagramPostedAt
+  → cualquier error en cualquier paso: log detallado (bookId, paso, mensaje),
+    no propagar, no lanzar excepción no controlada
+```
+
+Si `SOCIAL_AUTOPOST_ENABLED` es `false`, `publishToInstagram` no hace nada
+(log de nivel debug y salida inmediata).
+
+## 6. Generación de la imagen de marca
+
+### 6.1 Librería y fuentes
+
+- `@napi-rs/canvas` para todo el compositing (imagen + texto).
+- Empaquetar en el repo los archivos de fuente `Fraunces` (weight 600) y
+  `Source Sans 3` (weights 400 y 600) como `.ttf`/`.otf`, por ejemplo en
+  `assets/fonts/`. Registrarlas con `GlobalFonts.registerFromPath()` al
+  arrancar el módulo.
+- **Importante:** `@napi-rs/canvas` no tiene ninguna fuente de iconos cargada.
+  La fila de estrellas (sección 6.3) se dibuja como un path vectorial simple
+  (polígono de 5 puntas, solo trazo, sin relleno), no como un carácter de una
+  fuente de iconos.
+
+### 6.2 Lienzo
+
+- Dimensiones: **1080 × 1350 px** (ratio 4:5, el máximo recomendado para
+  feed de Instagram).
+- Formato de salida: **JPEG**, calidad ~90. Instagram rechaza PNG/WebP en
+  posts de feed.
+
+### 6.3 Composición (de arriba abajo)
+
+Basado en el mockup aprobado:
+
+1. **Fondo:** relleno sólido `#3D3A35` (tinta).
+2. **Fila de 5 estrellas**, centrada horizontalmente cerca de la parte
+   superior. Solo trazo (sin rellenar, deliberadamente — no debe leerse como
+   una puntuación real dada por Reseñan Sancho), color `#F2B705` (mustaza).
+3. **Portada del libro:** descargar la imagen desde la URL de Cloudinary del
+   campo `cover` del libro. Dibujar recortada en un rectángulo de esquinas
+   redondeadas (`border-radius` equivalente ~36px a esta resolución),
+   ocupando aproximadamente el 47% del ancho del lienzo, manteniendo ratio
+   3:4 (≈ 504 × 674 px).
+   - **Si la descarga de la portada falla** (timeout, error de red): abortar
+     la publicación de este libro por completo. No publicar una imagen sin
+     la portada real — mejor no publicar que publicar algo incompleto. Log
+     con el `bookId` y el error.
+4. **Insignia de género**, debajo de la portada: fondo `rgba(251,241,216,0.1)`,
+   borde `1px solid rgba(251,241,216,0.28)`, texto en `#FBF1D8` (crema),
+   mayúsculas, `Source Sans 3` 600.
+5. **Título del libro:** `Fraunces` 600, color `#FBF1D8`, centrado. Debe
+   partirse en varias líneas automáticamente según el ancho disponible — medir
+   el ancho del texto con el contexto de canvas y romper por palabras, no a
+   mitad de palabra. No hay límite estricto de líneas, pero conviene un
+   tamaño de fuente que en la práctica quepan 1–3 líneas para títulos típicos.
+6. **Autor:** `Source Sans 3`, color `#F2B705` (mustaza), tamaño menor que el
+   título. Formato: `por {nombre del autor}`.
+7. **Chips de formato:** uno por cada formato disponible del libro, en fila,
+   centrados y con salto de línea si no caben todos. Mismo estilo visual que
+   la insignia de género (fondo translúcido crema, borde crema, texto crema),
+   mayúsculas.
+
+### 6.4 Subida a Cloudinary (solo en modo real, no en dry-run)
+
+Subir el buffer JPEG a la cuenta de Cloudinary ya en uso, en una carpeta
+nueva `instagram-posts/`. Guardar el `secure_url` devuelto — es la URL que se
+pasa a la Graph API como `image_url`.
+
+## 7. Modo dry-run (`IG_DRY_RUN`)
+
+Pensado para poder probar todo el flujo en local sin publicar nada real ni
+depender de una cuenta de pruebas de Instagram.
+
+Cuando `IG_DRY_RUN=true`:
+
+- **Sí se genera** la imagen de marca completa (se ejercita toda la lógica
+  de compositing y de salto de línea del título).
+- La imagen generada **se guarda en disco local** en vez de subirse a
+  Cloudinary — por ejemplo en `./tmp/ig-preview-<bookId>-<timestamp>.jpg`
+  (añadir `tmp/` a `.gitignore` si no lo está ya). Esto permite abrir el
+  archivo y revisar visualmente el resultado sin tocar Cloudinary ni Meta.
+- **Sí se construye** el caption completo.
+- **No se sube nada a Cloudinary** y **no se hace ninguna llamada a la Graph
+  API** (ni creación de contenedor ni publicación).
+- Se loguea en consola: el caption completo, la ruta del archivo local
+  generado, y el `ig-user-id` que se habría usado.
+- **No se actualiza `instagramPostedAt`** — como no se ha publicado nada de
+  verdad, no debe quedar marcado como publicado.
+
+Cuando `IG_DRY_RUN=false`, se ejecuta el flujo real completo (subida a
+Cloudinary + Graph API).
+
+**Valor por defecto:** `true` en desarrollo local, `false` en Heroku
+(producción). Esto debe quedar documentado en el `README` del repo backend,
+explicando qué hace la variable y dónde queda guardada la imagen de
+previsualización cuando está activa.
+
+## 8. Construcción del caption
+
+Plantilla (contenido de producto, en español — según convención del proyecto,
+el copy visible para el usuario final va en español aunque el código esté en
+inglés):
+
+```
+📚 Nuevo libro disponible para reseñar: {title}, de {author}.
+
+Disponible en {formats}.
+
+{synopsisExcerpt}…
+
+Pide tu ejemplar gratuito desde el enlace en nuestra bio.
+```
+
+- **`{formats}`:** unir la lista de formatos de forma natural en español, no
+  con comas sueltas. Un solo formato: tal cual. Dos: `"X y Y"`. Tres o más:
+  `"X, Y y Z"`.
+- **`{synopsisExcerpt}`:** recortar la sinopsis del libro a **~200
+  caracteres**, cortando en el último espacio antes del límite (no a mitad
+  de palabra), y añadir `…` al final. No incluir la sinopsis completa: el
+  caption se trunca a 125 caracteres visibles en el feed antes de "ver más",
+  y una sinopsis de hasta 2000 caracteres generaría un muro de texto.
+- Sin hashtags por ahora — no añadir ninguno aunque quede espacio.
+
+## 9. Llamadas a la Graph API (solo modo real)
+
+Usar `IG_PAGE_ACCESS_TOKEN` como `access_token` en las tres llamadas.
+
+1. **Crear el contenedor de medios:**
+   `POST /v26.0/{IG_BUSINESS_ACCOUNT_ID}/media`
+   body: `{ image_url: <secure_url de Cloudinary>, caption: <caption> }`
+   → devuelve `{ id: containerId }`
+
+2. **Esperar a que el contenedor esté listo:**
+   `GET /v26.0/{containerId}?fields=status_code`
+   Repetir con backoff corto hasta que `status_code === "FINISHED"`, con un
+   límite razonable de intentos (p. ej. 10 intentos, unos segundos entre
+   cada uno). Si se agota el límite sin llegar a `FINISHED`, abortar y
+   loguear — no forzar la publicación de un contenedor que no ha terminado
+   de procesarse.
+
+3. **Publicar:**
+   `POST /v26.0/{IG_BUSINESS_ACCOUNT_ID}/media_publish`
+   body: `{ creation_id: containerId }`
+
+Si cualquiera de las tres llamadas devuelve error, loguear la respuesta
+completa de la API (código y mensaje de error de Meta) junto con el
+`bookId`, y no continuar con los pasos siguientes.
+
+## 10. Manejo de errores
+
+Siguiendo el principio ya establecido para servicios externos (igual que con
+Mailchimp o el envío de correo): un fallo en Instagram **nunca** debe tumbar
+ni retrasar la petición de creación del libro. Toda la función
+`publishToInstagram` va envuelta en un `try/catch` de nivel superior; los
+`catch` de cada paso interno registran el contexto suficiente para depurar
+(`bookId`, paso concreto, mensaje de error) sin filtrar secretos (nunca
+loguear el `access_token` completo).
+
+## 11. Fuera de alcance de este spec (para más adelante)
+
+- Renovación automática del `IG_PAGE_ACCESS_TOKEN` antes de que se invalide.
+- Reintentos automáticos ante fallos transitorios de la Graph API.
+- Hashtags dinámicos por género.
+- Publicación manual/bajo demanda para libros ya existentes (este spec cubre
+  solo el disparador automático en creación).
+
+## 12. Checklist de verificación antes de cerrar
+
+- [ ] Con `IG_DRY_RUN=true`, crear un libro localmente genera un `.jpg` en
+      `tmp/` visualmente correcto (portada, título con salto de línea si es
+      largo, formatos, sin errores en consola) y no llama a Cloudinary ni a
+      Meta.
+- [ ] Con `IG_DRY_RUN=false` contra una cuenta de prueba (no la oficial),
+      el flujo completo publica correctamente y `instagramPostedAt` queda
+      seteado.
+- [ ] Si se fuerza un fallo (por ejemplo, URL de portada rota), la creación
+      del libro responde con éxito igualmente y el error queda logueado.
+- [ ] `SOCIAL_AUTOPOST_ENABLED=false` desactiva la feature sin tocar código.
+- [ ] El `README` documenta `IG_DRY_RUN` y dónde aparece la imagen de
+      previsualización.

--- a/lib/instagram/caption.js
+++ b/lib/instagram/caption.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const SYNOPSIS_MAX_LENGTH = 200;
+
+// The stored format values come from the frontend form ('papel', 'epub'…).
+// Only the ones that read badly in lowercase get a display label; anything
+// unknown is shown as stored so a new format never breaks the caption.
+const FORMAT_LABELS = {
+  epub: 'ePub',
+  mobi: 'Mobi',
+  pdf: 'PDF',
+};
+
+function formatLabel(format) {
+  const key = String(format).trim().toLowerCase();
+  return FORMAT_LABELS[key] || String(format).trim();
+}
+
+// Natural Spanish enumeration: 'X', 'X y Y', 'X, Y y Z'.
+function joinFormats(formats = []) {
+  const labels = formats.map(formatLabel).filter(Boolean);
+  if (labels.length === 0) {
+    return '';
+  }
+  if (labels.length === 1) {
+    return labels[0];
+  }
+  return `${labels.slice(0, -1).join(', ')} y ${labels[labels.length - 1]}`;
+}
+
+// Cuts to ~200 characters on a word boundary. The feed only shows ~125
+// characters before "ver más", so a full 2000-char synopsis would be a wall of
+// text (docs/instagram-autopost-spec.md, section 8).
+function synopsisExcerpt(synopsis = '') {
+  const clean = String(synopsis).replace(/\s+/g, ' ').trim();
+  if (clean.length <= SYNOPSIS_MAX_LENGTH) {
+    return clean;
+  }
+  const cut = clean.slice(0, SYNOPSIS_MAX_LENGTH);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).replace(/[.,;:]$/, '');
+}
+
+// No hashtags: deliberate product decision, do not add any.
+function buildCaption(book) {
+  const heading = book.author
+    ? `📚 Nuevo libro disponible para reseñar: ${book.title}, de ${book.author}.`
+    : `📚 Nuevo libro disponible para reseñar: ${book.title}.`;
+
+  const formats = joinFormats(book.formats);
+  const excerpt = synopsisExcerpt(book.synopsis);
+  const truncated = excerpt.length < String(book.synopsis || '').replace(/\s+/g, ' ').trim().length;
+
+  const blocks = [heading];
+  if (formats) {
+    blocks.push(`Disponible en ${formats}.`);
+  }
+  if (excerpt) {
+    blocks.push(truncated ? `${excerpt}…` : excerpt);
+  }
+  blocks.push('Pide tu ejemplar gratuito desde el enlace en nuestra bio.');
+
+  return blocks.join('\n\n');
+}
+
+module.exports = { buildCaption, joinFormats, synopsisExcerpt };

--- a/lib/instagram/cloudinary.js
+++ b/lib/instagram/cloudinary.js
@@ -1,0 +1,40 @@
+'use strict';
+const { v2: cloudinary } = require('cloudinary');
+
+// The Graph API only accepts a public image_url, never a raw buffer, so the
+// generated JPEG is uploaded to the Cloudinary account the covers already use,
+// under its own instagram-posts/ folder.
+const FOLDER = 'instagram-posts';
+
+// Credentials are read per call so the feature follows the same "no redeploy
+// needed" rule as the rest of the config (docs/instagram-autopost-spec.md, §3).
+function configure() {
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+  const apiKey = process.env.CLOUDINARY_API_KEY;
+  const apiSecret = process.env.CLOUDINARY_API_SECRET;
+
+  if (!cloudName || !apiKey || !apiSecret) {
+    throw new Error('missing Cloudinary credentials');
+  }
+  cloudinary.config({ cloud_name: cloudName, api_key: apiKey, api_secret: apiSecret, secure: true });
+}
+
+function uploadImage(buffer, bookId) {
+  configure();
+
+  return new Promise((resolve, reject) => {
+    const stream = cloudinary.uploader.upload_stream(
+      { folder: FOLDER, public_id: `book-${bookId}-${Date.now()}`, resource_type: 'image', format: 'jpg' },
+      (error, result) => {
+        if (error) {
+          reject(new Error(error.message || 'Cloudinary upload failed'));
+          return;
+        }
+        resolve(result.secure_url);
+      }
+    );
+    stream.end(buffer);
+  });
+}
+
+module.exports = { uploadImage, FOLDER };

--- a/lib/instagram/config.js
+++ b/lib/instagram/config.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Every value is read at call time, never at module load: that way the feature
+// can be switched off (or moved out of dry-run) by changing a Heroku config var
+// without a redeploy.
+function readFlag(name, defaultValue) {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    return defaultValue;
+  }
+  return value === 'true';
+}
+
+function getConfig() {
+  return {
+    enabled: readFlag('SOCIAL_AUTOPOST_ENABLED', false),
+    // Dry-run is the safe default: a missing/typo'd config var must never end up
+    // publishing to the real account.
+    dryRun: readFlag('IG_DRY_RUN', true),
+    accessToken: process.env.IG_PAGE_ACCESS_TOKEN,
+    businessAccountId: process.env.IG_BUSINESS_ACCOUNT_ID,
+  };
+}
+
+module.exports = { getConfig };

--- a/lib/instagram/fonts.js
+++ b/lib/instagram/fonts.js
@@ -1,0 +1,47 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { GlobalFonts } = require('@napi-rs/canvas');
+const logger = require('./logger');
+
+// Fonts are resolved once per process. Any .ttf/.otf dropped into assets/fonts/
+// is registered and wins over the system fonts, so swapping in the brand faces
+// later is a drop-in change with no code edit.
+const FONTS_DIR = path.join(__dirname, '..', '..', 'assets', 'fonts');
+
+// Generic, widely available faces: the brand fonts are not bundled yet, so the
+// image falls back to whatever the host provides (macOS locally, DejaVu/
+// Liberation on the Heroku stack).
+const SERIF_PREFERENCE = ['Fraunces', 'Georgia', 'Times New Roman', 'DejaVu Serif', 'Liberation Serif', 'Noto Serif', 'serif'];
+const SANS_PREFERENCE = ['Source Sans 3', 'Helvetica Neue', 'Helvetica', 'Arial', 'DejaVu Sans', 'Liberation Sans', 'Noto Sans', 'sans-serif'];
+
+let resolved = null;
+
+function registerBundledFonts() {
+  if (!fs.existsSync(FONTS_DIR)) {
+    return;
+  }
+  fs.readdirSync(FONTS_DIR)
+    .filter((file) => /\.(ttf|otf)$/i.test(file))
+    .forEach((file) => GlobalFonts.registerFromPath(path.join(FONTS_DIR, file)));
+}
+
+function pick(preference, available) {
+  return preference.find((family) => available.has(family)) || preference[preference.length - 1];
+}
+
+function getFonts() {
+  if (resolved) {
+    return resolved;
+  }
+  registerBundledFonts();
+  const available = new Set(GlobalFonts.families.map((font) => font.family));
+  resolved = {
+    serif: pick(SERIF_PREFERENCE, available),
+    sans: pick(SANS_PREFERENCE, available),
+  };
+  logger.debug('fonts resolved', resolved);
+  return resolved;
+}
+
+module.exports = { getFonts };

--- a/lib/instagram/genreLabels.js
+++ b/lib/instagram/genreLabels.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Spanish display labels for the genre badge. Books store the 3-letter code
+// (utils/constants/genres.js); the English `name` is accepted too because older
+// documents were saved with it.
+const LABELS = {
+  ADV: 'aventura', BIO: 'biografía', CIF: 'ciencia ficción', CRI: 'crimen',
+  ERO: 'erótica', FAN: 'fantasía', FCH: 'infantil', JUV: 'juvenil',
+  HIF: 'ficción histórica', HUM: 'humor', POE: 'poesía', POL: 'policial',
+  PSD: 'drama psicológico', ROM: 'romántica', SUS: 'suspense',
+  TER: 'terror', THR: 'thriller',
+};
+
+const BY_NAME = {
+  adventure: 'ADV', biography: 'BIO', cienceFiction: 'CIF', crime: 'CRI',
+  erotica: 'ERO', fantasy: 'FAN', forChildren: 'FCH', juvenile: 'JUV',
+  historicalFiction: 'HIF', humor: 'HUM', poetry: 'POE', policial: 'POL',
+  psychologicalDrama: 'PSD', romantic: 'ROM', suspense: 'SUS',
+  terror: 'TER', thriller: 'THR',
+};
+
+function genreLabel(genre) {
+  if (!genre) {
+    return '';
+  }
+  const code = LABELS[genre] ? genre : BY_NAME[genre];
+  return LABELS[code] || String(genre);
+}
+
+module.exports = { genreLabel };

--- a/lib/instagram/graphApi.js
+++ b/lib/instagram/graphApi.js
@@ -1,0 +1,62 @@
+'use strict';
+const logger = require('./logger');
+
+const GRAPH_VERSION = 'v26.0';
+const BASE_URL = `https://graph.facebook.com/${GRAPH_VERSION}`;
+const STATUS_ATTEMPTS = 10;
+const STATUS_DELAY_MS = 3000;
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Meta answers errors with { error: { message, code, error_subcode } }. The
+// message is surfaced in full (it is what makes a failure debuggable) but the
+// access token never leaves this module.
+async function graphRequest(url, options) {
+  const response = await fetch(url, options);
+  const body = await response.json().catch(() => ({}));
+
+  if (!response.ok || body.error) {
+    const error = body.error || {};
+    throw new Error(`Graph API ${response.status}: ${error.message || 'unknown error'}${error.code ? ` (code ${error.code})` : ''}`);
+  }
+  return body;
+}
+
+async function createMediaContainer({ igUserId, accessToken, imageUrl, caption }) {
+  const body = new URLSearchParams({ image_url: imageUrl, caption, access_token: accessToken });
+  const result = await graphRequest(`${BASE_URL}/${igUserId}/media`, { method: 'POST', body });
+
+  if (!result.id) {
+    throw new Error('Graph API did not return a container id');
+  }
+  return result.id;
+}
+
+// Instagram processes the container asynchronously; publishing one that is not
+// FINISHED fails, so poll with a short backoff and give up rather than force it.
+async function waitForContainer({ containerId, accessToken, attempts = STATUS_ATTEMPTS, delayMs = STATUS_DELAY_MS }) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const url = `${BASE_URL}/${containerId}?fields=status_code&access_token=${encodeURIComponent(accessToken)}`;
+    const { status_code: statusCode } = await graphRequest(url, { method: 'GET' });
+
+    if (statusCode === 'FINISHED') {
+      return;
+    }
+    if (statusCode === 'ERROR' || statusCode === 'EXPIRED') {
+      throw new Error(`container ${containerId} ended in status ${statusCode}`);
+    }
+    logger.debug('container not ready yet', { containerId, statusCode, attempt });
+    if (attempt < attempts) {
+      await wait(delayMs);
+    }
+  }
+  throw new Error(`container ${containerId} was not FINISHED after ${attempts} attempts`);
+}
+
+async function publishContainer({ igUserId, accessToken, containerId }) {
+  const body = new URLSearchParams({ creation_id: containerId, access_token: accessToken });
+  const result = await graphRequest(`${BASE_URL}/${igUserId}/media_publish`, { method: 'POST', body });
+  return result.id;
+}
+
+module.exports = { createMediaContainer, waitForContainer, publishContainer, GRAPH_VERSION };

--- a/lib/instagram/image.js
+++ b/lib/instagram/image.js
@@ -1,0 +1,266 @@
+'use strict';
+const { createCanvas, loadImage } = require('@napi-rs/canvas');
+const { getFonts } = require('./fonts');
+const { genreLabel } = require('./genreLabels');
+
+const WIDTH = 1080;
+const HEIGHT = 1350;
+const JPEG_QUALITY = 90;
+
+const INK = '#3D3A35';
+const CREAM = '#FBF1D8';
+const MUSTARD = '#F2B705';
+const CHIP_BACKGROUND = 'rgba(251,241,216,0.1)';
+const CHIP_BORDER = 'rgba(251,241,216,0.28)';
+
+const COVER_WIDTH = Math.round(WIDTH * 0.47);          // ≈ 508 px
+const COVER_HEIGHT = Math.round(COVER_WIDTH * 4 / 3);  // 3:4 ratio
+const COVER_RADIUS = 36;
+const COVER_TOP = 150;
+
+const STARS_TOP = 78;
+const STAR_RADIUS = 22;
+const STAR_GAP = 26;
+
+const TITLE_SIZE = 56;
+const TITLE_LINE_HEIGHT = 68;
+const AUTHOR_SIZE = 36;
+const CHIP_TEXT_SIZE = 24;
+const CHIP_HEIGHT = 52;
+const CHIP_PADDING = 26;
+const CHIP_GAP = 14;
+
+const BOTTOM_MARGIN = 60;
+const COVER_FETCH_TIMEOUT_MS = 10000;
+
+// Downloads the Cloudinary cover. A failure here aborts the whole publication:
+// posting a branded image without the real cover is worse than not posting.
+async function fetchCover(coverUrl) {
+  const response = await fetch(coverUrl, { signal: AbortSignal.timeout(COVER_FETCH_TIMEOUT_MS) });
+  if (!response.ok) {
+    throw new Error(`cover download failed with status ${response.status}`);
+  }
+  return loadImage(Buffer.from(await response.arrayBuffer()));
+}
+
+function roundedRectPath(ctx, x, y, width, height, radius) {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + width, y, x + width, y + height, radius);
+  ctx.arcTo(x + width, y + height, x, y + height, radius);
+  ctx.arcTo(x, y + height, x, y, radius);
+  ctx.arcTo(x, y, x + width, y, radius);
+  ctx.closePath();
+}
+
+// Stroke-only 5-point star: deliberately not filled, so the row never reads as
+// a real rating given by Reseñan Sancho.
+function starPath(ctx, cx, cy, outerRadius) {
+  const innerRadius = outerRadius * 0.42;
+  ctx.beginPath();
+  for (let i = 0; i < 10; i += 1) {
+    const radius = i % 2 === 0 ? outerRadius : innerRadius;
+    const angle = (Math.PI / 5) * i - Math.PI / 2;
+    const x = cx + Math.cos(angle) * radius;
+    const y = cy + Math.sin(angle) * radius;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.closePath();
+}
+
+function drawStars(ctx) {
+  const step = STAR_RADIUS * 2 + STAR_GAP;
+  const firstX = WIDTH / 2 - (step * 4) / 2;
+  ctx.strokeStyle = MUSTARD;
+  ctx.lineWidth = 3;
+  ctx.lineJoin = 'round';
+  for (let i = 0; i < 5; i += 1) {
+    starPath(ctx, firstX + step * i, STARS_TOP + STAR_RADIUS, STAR_RADIUS);
+    ctx.stroke();
+  }
+}
+
+// Draws the cover cropped like CSS object-fit: cover inside a rounded rect.
+function drawCover(ctx, cover) {
+  const x = (WIDTH - COVER_WIDTH) / 2;
+  const scale = Math.max(COVER_WIDTH / cover.width, COVER_HEIGHT / cover.height);
+  const drawWidth = cover.width * scale;
+  const drawHeight = cover.height * scale;
+
+  ctx.save();
+  roundedRectPath(ctx, x, COVER_TOP, COVER_WIDTH, COVER_HEIGHT, COVER_RADIUS);
+  ctx.clip();
+  ctx.drawImage(
+    cover,
+    x + (COVER_WIDTH - drawWidth) / 2,
+    COVER_TOP + (COVER_HEIGHT - drawHeight) / 2,
+    drawWidth,
+    drawHeight
+  );
+  ctx.restore();
+
+  return COVER_TOP + COVER_HEIGHT;
+}
+
+// Word-wraps by measuring the real text width; never breaks mid-word.
+function wrapText(ctx, text, maxWidth) {
+  const words = String(text || '').split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = '';
+
+  words.forEach((word) => {
+    const candidate = current ? `${current} ${word}` : word;
+    if (current && ctx.measureText(candidate).width > maxWidth) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  });
+  if (current) {
+    lines.push(current);
+  }
+  return lines;
+}
+
+function drawChip(ctx, label, x, y, width) {
+  ctx.fillStyle = CHIP_BACKGROUND;
+  roundedRectPath(ctx, x, y, width, CHIP_HEIGHT, CHIP_HEIGHT / 2);
+  ctx.fill();
+  ctx.strokeStyle = CHIP_BORDER;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  ctx.fillStyle = CREAM;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(label, x + width / 2, y + CHIP_HEIGHT / 2 + 1);
+}
+
+// Lays out chips in centered rows, wrapping when a row would overflow.
+function layoutChips(ctx, labels, fonts) {
+  ctx.font = `600 ${CHIP_TEXT_SIZE}px "${fonts.sans}"`;
+  const maxRowWidth = WIDTH - 120;
+  const chips = labels.map((label) => ({
+    label,
+    width: ctx.measureText(label).width + CHIP_PADDING * 2,
+  }));
+
+  const rows = [];
+  let row = [];
+  let rowWidth = 0;
+  chips.forEach((chip) => {
+    const nextWidth = rowWidth ? rowWidth + CHIP_GAP + chip.width : chip.width;
+    if (row.length && nextWidth > maxRowWidth) {
+      rows.push({ chips: row, width: rowWidth });
+      row = [chip];
+      rowWidth = chip.width;
+    } else {
+      row.push(chip);
+      rowWidth = nextWidth;
+    }
+  });
+  if (row.length) {
+    rows.push({ chips: row, width: rowWidth });
+  }
+
+  return { rows, height: rows.length * (CHIP_HEIGHT + CHIP_GAP) };
+}
+
+function drawChips(ctx, { rows }, top, fonts) {
+  ctx.font = `600 ${CHIP_TEXT_SIZE}px "${fonts.sans}"`;
+  let y = top;
+  rows.forEach(({ chips: rowChips, width }) => {
+    let x = (WIDTH - width) / 2;
+    rowChips.forEach((chip) => {
+      drawChip(ctx, chip.label, x, y, chip.width);
+      x += chip.width + CHIP_GAP;
+    });
+    y += CHIP_HEIGHT + CHIP_GAP;
+  });
+  return y;
+}
+
+// Longer titles get a smaller face so the block below the cover always fits in
+// the canvas instead of running off the bottom edge.
+function fitTitle(ctx, title, fonts, availableHeight, fixedHeight) {
+  const sizes = [TITLE_SIZE, 50, 44, 38];
+  let chosen = null;
+  sizes.forEach((size) => {
+    if (chosen) {
+      return;
+    }
+    ctx.font = `600 ${size}px "${fonts.serif}"`;
+    const lines = wrapText(ctx, title, WIDTH - 160);
+    const lineHeight = Math.round(size * (TITLE_LINE_HEIGHT / TITLE_SIZE));
+    if (fixedHeight + lines.length * lineHeight <= availableHeight) {
+      chosen = { size, lines, lineHeight };
+    }
+  });
+  if (!chosen) {
+    const size = sizes[sizes.length - 1];
+    ctx.font = `600 ${size}px "${fonts.serif}"`;
+    chosen = {
+      size,
+      lines: wrapText(ctx, title, WIDTH - 160),
+      lineHeight: Math.round(size * (TITLE_LINE_HEIGHT / TITLE_SIZE)),
+    };
+  }
+  return chosen;
+}
+
+// Renders the 1080x1350 branded image and returns a JPEG buffer. Instagram
+// rejects PNG/WebP in feed posts.
+async function renderBookImage(book) {
+  const fonts = getFonts();
+  const cover = await fetchCover(book.cover);
+
+  const canvas = createCanvas(WIDTH, HEIGHT);
+  const ctx = canvas.getContext('2d');
+
+  ctx.fillStyle = INK;
+  ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+  drawStars(ctx);
+  let cursor = drawCover(ctx, cover) + 46;
+
+  const genre = genreLabel(book.genre);
+  if (genre) {
+    const genreChips = layoutChips(ctx, [genre.toUpperCase()], fonts);
+    cursor = drawChips(ctx, genreChips, cursor, fonts) + 18;
+  }
+
+  const formats = (book.formats || []).map((format) => String(format).toUpperCase());
+  const formatChips = formats.length ? layoutChips(ctx, formats, fonts) : { rows: [], height: 0 };
+  const authorHeight = book.author ? 14 + AUTHOR_SIZE + 30 : 0;
+  const title = fitTitle(ctx, book.title, fonts, HEIGHT - BOTTOM_MARGIN - cursor, authorHeight + formatChips.height);
+
+  ctx.font = `600 ${title.size}px "${fonts.serif}"`;
+  ctx.fillStyle = CREAM;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  title.lines.forEach((line) => {
+    ctx.fillText(line, WIDTH / 2, cursor);
+    cursor += title.lineHeight;
+  });
+
+  if (book.author) {
+    cursor += 14;
+    ctx.font = `${AUTHOR_SIZE}px "${fonts.sans}"`;
+    ctx.fillStyle = MUSTARD;
+    ctx.fillText(`por ${book.author}`, WIDTH / 2, cursor);
+    cursor += AUTHOR_SIZE + 30;
+  }
+
+  if (formats.length) {
+    drawChips(ctx, formatChips, cursor, fonts);
+  }
+
+  return canvas.encode('jpeg', JPEG_QUALITY);
+}
+
+module.exports = { renderBookImage, wrapText, WIDTH, HEIGHT };

--- a/lib/instagram/index.js
+++ b/lib/instagram/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const { getConfig } = require('./config');
 const logger = require('./logger');
+const { buildCaption } = require('./caption');
 
 // Fire-and-forget publication of a freshly created book to the official
 // Instagram account. Never throws and never blocks the request that triggered
@@ -30,7 +31,10 @@ async function publishToInstagram(book) {
   try {
     const bookData = await buildBookData(book);
     logger.info('publishing book', { bookId: bookData.id, dryRun });
-    // Steps 2-4 of docs/instagram-autopost-spec.md (caption, image, upload and
+
+    const caption = buildCaption(bookData);
+    logger.debug('caption built', { bookId: bookData.id, caption });
+    // Steps 3-4 of docs/instagram-autopost-spec.md (image generation, upload and
     // Graph API calls) are wired in from here.
   } catch (error) {
     logger.error('publish', book._id, error);

--- a/lib/instagram/index.js
+++ b/lib/instagram/index.js
@@ -4,13 +4,16 @@ const logger = require('./logger');
 const { buildCaption } = require('./caption');
 const { renderBookImage } = require('./image');
 const { savePreview } = require('./preview');
+const { uploadImage } = require('./cloudinary');
+const { createMediaContainer, waitForContainer, publishContainer } = require('./graphApi');
+const Book = require('../../models/book');
 
 // Fire-and-forget publication of a freshly created book to the official
 // Instagram account. Never throws and never blocks the request that triggered
 // it: every failure is logged and swallowed, same principle already applied to
 // Mailchimp and the email transporter.
 async function publishToInstagram(book) {
-  const { enabled, dryRun, businessAccountId } = getConfig();
+  const { enabled, dryRun, businessAccountId, accessToken } = getConfig();
 
   if (!enabled) {
     logger.debug('feature disabled, skipping', { bookId: book && String(book._id) });
@@ -49,8 +52,26 @@ async function publishToInstagram(book) {
       return;
     }
 
-    // Step 4 of docs/instagram-autopost-spec.md (Cloudinary upload and Graph API
-    // calls) is wired in from here.
+    if (!accessToken || !businessAccountId) {
+      throw new Error('missing IG_PAGE_ACCESS_TOKEN or IG_BUSINESS_ACCOUNT_ID');
+    }
+
+    const imageUrl = await uploadImage(image, bookData.id);
+    const containerId = await createMediaContainer({
+      igUserId: businessAccountId,
+      accessToken,
+      imageUrl,
+      caption,
+    });
+    await waitForContainer({ containerId, accessToken });
+    const mediaId = await publishContainer({ igUserId: businessAccountId, accessToken, containerId });
+
+    // Marked only after a real publication, so a retry never duplicates a post.
+    const postedAt = new Date();
+    await Book.updateOne({ _id: bookData.id }, { instagramPostedAt: postedAt });
+    book.instagramPostedAt = postedAt;
+
+    logger.info('published', { bookId: bookData.id, mediaId });
   } catch (error) {
     logger.error('publish', book._id, error);
   }

--- a/lib/instagram/index.js
+++ b/lib/instagram/index.js
@@ -2,13 +2,15 @@
 const { getConfig } = require('./config');
 const logger = require('./logger');
 const { buildCaption } = require('./caption');
+const { renderBookImage } = require('./image');
+const { savePreview } = require('./preview');
 
 // Fire-and-forget publication of a freshly created book to the official
 // Instagram account. Never throws and never blocks the request that triggered
 // it: every failure is logged and swallowed, same principle already applied to
 // Mailchimp and the email transporter.
 async function publishToInstagram(book) {
-  const { enabled, dryRun } = getConfig();
+  const { enabled, dryRun, businessAccountId } = getConfig();
 
   if (!enabled) {
     logger.debug('feature disabled, skipping', { bookId: book && String(book._id) });
@@ -33,9 +35,22 @@ async function publishToInstagram(book) {
     logger.info('publishing book', { bookId: bookData.id, dryRun });
 
     const caption = buildCaption(bookData);
-    logger.debug('caption built', { bookId: bookData.id, caption });
-    // Steps 3-4 of docs/instagram-autopost-spec.md (image generation, upload and
-    // Graph API calls) are wired in from here.
+    const image = await renderBookImage(bookData);
+
+    if (dryRun) {
+      const previewPath = await savePreview(image, bookData.id);
+      // Nothing was really published, so instagramPostedAt stays untouched.
+      logger.info('dry run, nothing published', {
+        bookId: bookData.id,
+        previewPath,
+        igUserId: businessAccountId,
+        caption,
+      });
+      return;
+    }
+
+    // Step 4 of docs/instagram-autopost-spec.md (Cloudinary upload and Graph API
+    // calls) is wired in from here.
   } catch (error) {
     logger.error('publish', book._id, error);
   }

--- a/lib/instagram/index.js
+++ b/lib/instagram/index.js
@@ -1,0 +1,61 @@
+'use strict';
+const { getConfig } = require('./config');
+const logger = require('./logger');
+
+// Fire-and-forget publication of a freshly created book to the official
+// Instagram account. Never throws and never blocks the request that triggered
+// it: every failure is logged and swallowed, same principle already applied to
+// Mailchimp and the email transporter.
+async function publishToInstagram(book) {
+  const { enabled, dryRun } = getConfig();
+
+  if (!enabled) {
+    logger.debug('feature disabled, skipping', { bookId: book && String(book._id) });
+    return;
+  }
+
+  if (!book) {
+    logger.debug('no book given, skipping');
+    return;
+  }
+
+  if (book.instagramPostedAt) {
+    logger.debug('book already posted, skipping', {
+      bookId: String(book._id),
+      instagramPostedAt: book.instagramPostedAt,
+    });
+    return;
+  }
+
+  try {
+    const bookData = await buildBookData(book);
+    logger.info('publishing book', { bookId: bookData.id, dryRun });
+    // Steps 2-4 of docs/instagram-autopost-spec.md (caption, image, upload and
+    // Graph API calls) are wired in from here.
+  } catch (error) {
+    logger.error('publish', book._id, error);
+  }
+}
+
+// Flattens the book into the plain data the caption and the image need, with
+// the author resolved to a display name.
+async function buildBookData(book) {
+  const populated = typeof book.populate === 'function'
+    ? await book.populate({ path: 'author', select: 'name lastName' })
+    : book;
+  const author = populated.author && populated.author.name
+    ? `${populated.author.name} ${populated.author.lastName || ''}`.trim()
+    : null;
+
+  return {
+    id: String(populated._id),
+    title: populated.title,
+    author,
+    genre: populated.genre,
+    synopsis: populated.synopsis,
+    cover: populated.cover,
+    formats: Array.isArray(populated.formats) ? populated.formats : [],
+  };
+}
+
+module.exports = { publishToInstagram, buildBookData };

--- a/lib/instagram/logger.js
+++ b/lib/instagram/logger.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// Single place to prefix and shape the Instagram autopost logs. Never log the
+// access token: only the step, the book and the error message.
+const PREFIX = '[instagram-autopost]';
+
+function info(message, context = {}) {
+  console.log(PREFIX, message, context);
+}
+
+function debug(message, context = {}) {
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+  console.log(PREFIX, message, context);
+}
+
+function error(step, bookId, err) {
+  console.error(PREFIX, 'error', {
+    step,
+    bookId: String(bookId),
+    message: err && err.message ? err.message : String(err),
+  });
+}
+
+module.exports = { info, debug, error };

--- a/lib/instagram/preview.js
+++ b/lib/instagram/preview.js
@@ -1,0 +1,17 @@
+'use strict';
+const fs = require('fs/promises');
+const path = require('path');
+
+// In dry-run the generated JPEG is written to ./tmp instead of being uploaded,
+// so the result can be reviewed by eye without touching Cloudinary or Meta.
+const PREVIEW_DIR = path.join(process.cwd(), 'tmp');
+
+async function savePreview(buffer, bookId) {
+  await fs.mkdir(PREVIEW_DIR, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filePath = path.join(PREVIEW_DIR, `ig-preview-${bookId}-${timestamp}.jpg`);
+  await fs.writeFile(filePath, buffer);
+  return filePath;
+}
+
+module.exports = { savePreview, PREVIEW_DIR };

--- a/models/book.js
+++ b/models/book.js
@@ -56,6 +56,12 @@ const BookSchema = Schema({
     type: Schema.ObjectId,
     ref: 'user'
   }],
+  // Set only after a real (non dry-run) Instagram publication, so the same book
+  // is never posted twice. See docs/instagram-autopost-spec.md.
+  instagramPostedAt: {
+    type: Date,
+    default: null,
+  },
 });
 
 // Serves the home "featured books" query: match copies > 0, sort by copies desc

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "backend",
       "version": "3.5.0",
       "dependencies": {
+        "@napi-rs/canvas": "^1.0.7",
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
@@ -1422,6 +1423,255 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.7.tgz",
+      "integrity": "sha512-26wVFEgs6gbe7wmzCrud1pK8q6oOgcUu7OOF24BuazB8ZUCskU9ZSLrCjoWIFVxx09rjAxsXxPleaWowHvdPCA==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.7",
+        "@napi-rs/canvas-darwin-arm64": "1.0.7",
+        "@napi-rs/canvas-darwin-x64": "1.0.7",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.7",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.7",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.7",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.7",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.7",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.7",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.7",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.7"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.7.tgz",
+      "integrity": "sha512-d5p4hHTykc/9PjiBXkvCH/IC5hT5jH7BjQ1u8ITq+G8x4VmvveOHdy/4BWYcC3ebWRmrG9zEc/oCTy+Yf3iZ4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.7.tgz",
+      "integrity": "sha512-jKfZl2QDqBr6/Ap/8NKkX0Po9SFfVjUPBJbQQmYGVtQQIazWWIAO60riH3Mz2sOyysa2oJO39sLEfXerypu0vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.7.tgz",
+      "integrity": "sha512-v1asrnKBu0tD+sdSD2qVIUfhoXSrr8LFTn7z76pN+8xsiOrmFcAVty57R/5DB8ZNqNLKsUBDXFSrzf4Wt9NaSg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.7.tgz",
+      "integrity": "sha512-c4Hcu4L5bXCgLY8jrZ2hy/Avl65MsbfH9DqNWrrd9InbpBZZF/rmrh7XkgmTUmOFcUrt/PaFSBinW2C0moDgcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.7.tgz",
+      "integrity": "sha512-OVW6T1x65BTVfWb//xylCoWxbdII+nzHu3L5T035aerBAnZ5e0nmeTMkMEO9qQrVJq4WcWW8hp+T0dF+JvJPUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.7.tgz",
+      "integrity": "sha512-KX/k1UO61XdKlXxhtIkq1ZUH8uP+NNK4vSrBcM2/4wWUUCZaG93BU5s0KuE9n+TFn0jEoqLSlXOuH1pYuV5dcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.7.tgz",
+      "integrity": "sha512-r+0Bg+fK8r2AsrbeT7JwBUAERZSjlyhfAMQfZE/zxYGmbswS92hN0FPjynVWbeuz5fIrLfZ6JA5pH8V6drN6qw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.7.tgz",
+      "integrity": "sha512-0tT9KzEcTfb6MWdUWIDfy6uq6UNF691r/9NfXxxl8s9+G5QrD7VP1UC+PAwzsCzJTClIKyidNau/grYTL+QmHw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.7.tgz",
+      "integrity": "sha512-rvT0xo1xA+C7e+U/2ngsxWsl9gC5knHU+z8KTT5VK0Zos4AQbWZvtjvegrmzxm4o2yHE32Lexj6CDEJNvuTczA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.7.tgz",
+      "integrity": "sha512-N6s3yoFFPUDkfRpjUiKERVYkli7ex5Sf0Bu/My6D6gOGYxYolC1KvL6x8U0aN+ScCWAzbkIWcMYR9g0OGsFuVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.7.tgz",
+      "integrity": "sha512-SKTNdBV/ljfhkPsLhXjm4x2PQ0ILpc0PhkBzRHuroJXidZUaF5yh0j3s3dIzB8PrRmW+nEASzyMTaWT3nH1ywQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.7",
         "bcrypt": "^6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@napi-rs/canvas": "^1.0.7",
         "bcrypt": "^6.0.0",
+        "cloudinary": "^2.10.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "debug": "^4.4.3",
@@ -2763,6 +2764,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.10.1.tgz",
+      "integrity": "sha512-0aqF/sGwm2dSM/Xse87EI5OpKcuX/hwoPPdUDTdUal6GMPKevtElcI3spcaeuzJJbcLkY3vJaF22q0u50VO5Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.23"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5242,6 +5255,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "seed": "node ./scripts/seed.js"
   },
   "dependencies": {
+    "@napi-rs/canvas": "^1.0.7",
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@napi-rs/canvas": "^1.0.7",
     "bcrypt": "^6.0.0",
+    "cloudinary": "^2.10.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "private": true,
   "engines": {
     "node": ">=22 <23"

--- a/routes/registerBook.js
+++ b/routes/registerBook.js
@@ -7,6 +7,7 @@ const {
   transporter,
   newBookTemplate
 } = require('../lib/email');
+const { publishToInstagram } = require('../lib/instagram');
 
 router.post('/', async function (req, res) {
   try {
@@ -29,6 +30,11 @@ router.post('/', async function (req, res) {
       });
     };
     sendMail();
+    // Not awaited on purpose: Instagram must never delay nor break the book
+    // creation response (docs/instagram-autopost-spec.md, section 10).
+    // The service already swallows its own errors; the .catch() is the last-resort
+    // guard so a bug there can never become an unhandled rejection.
+    publishToInstagram(newBook).catch(() => {});
     res.json({
       success: true,
       message: '¡Libro registrado! Puedes editarlo desde la sección "Mis Libros". ¡No te olvides de agregar ejemplares con la opción PROMOCIONAR!'

--- a/scripts/instagramPreview.js
+++ b/scripts/instagramPreview.js
@@ -1,0 +1,26 @@
+'use strict';
+// Renders a sample Instagram image into tmp/ without touching the database or
+// any external service. Useful to review the layout by eye:
+//   node scripts/instagramPreview.js
+const { renderBookImage } = require('../lib/instagram/image');
+const { buildCaption } = require('../lib/instagram/caption');
+const { savePreview } = require('../lib/instagram/preview');
+
+const sample = {
+  id: 'preview',
+  title: process.argv[2] || 'El extraño caso del doctor Jekyll y el señor Hyde',
+  author: 'Robert Louis Stevenson',
+  genre: 'SUS',
+  cover: process.argv[3] || 'https://picsum.photos/seed/jekyll/600/800',
+  formats: ['papel', 'epub', 'pdf', 'audiolibro'],
+  synopsis: 'El abogado Utterson investiga la extraña relación entre su viejo amigo, el respetable doctor Jekyll, y el siniestro señor Hyde, un hombre que despierta el rechazo instintivo de cuantos lo tratan y del que nadie conoce el origen.',
+};
+
+(async () => {
+  const buffer = await renderBookImage(sample);
+  const filePath = await savePreview(buffer, sample.id);
+  console.log('\n--- caption ---\n');
+  console.log(buildCaption(sample));
+  console.log('\n--- image ---\n');
+  console.log(filePath);
+})();

--- a/tests/instagram.test.js
+++ b/tests/instagram.test.js
@@ -1,6 +1,10 @@
 jest.mock('../models/book', () => require('./helpers/modelMock').makeModelMock(['findOne']));
+jest.mock('../lib/instagram/image', () => ({ renderBookImage: jest.fn().mockResolvedValue(Buffer.from('jpeg')) }));
+jest.mock('../lib/instagram/preview', () => ({ savePreview: jest.fn().mockResolvedValue('/tmp/ig-preview-b1.jpg') }));
 
 const { publishToInstagram, buildBookData } = require('../lib/instagram');
+const { renderBookImage } = require('../lib/instagram/image');
+const { savePreview } = require('../lib/instagram/preview');
 
 const bookDoc = (overrides = {}) => ({
   _id: 'b1',
@@ -55,6 +59,42 @@ describe('publishToInstagram', () => {
       '[instagram-autopost]',
       'error',
       expect.objectContaining({ step: 'publish', bookId: 'b1', message: 'boom' })
+    );
+  });
+
+  test('in dry run it renders and saves the preview without marking the book as posted', async () => {
+    process.env.IG_BUSINESS_ACCOUNT_ID = '17841405744435526';
+    const book = bookDoc({ populate: jest.fn().mockResolvedValue(bookDoc()), save: jest.fn() });
+
+    await publishToInstagram(book);
+
+    expect(renderBookImage).toHaveBeenCalledWith(expect.objectContaining({ id: 'b1', title: 'El libro' }));
+    expect(savePreview).toHaveBeenCalledWith(expect.any(Buffer), 'b1');
+    expect(book.instagramPostedAt).toBeNull();
+    expect(book.save).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
+      '[instagram-autopost]',
+      'dry run, nothing published',
+      expect.objectContaining({
+        bookId: 'b1',
+        previewPath: '/tmp/ig-preview-b1.jpg',
+        igUserId: '17841405744435526',
+        caption: expect.stringContaining('Nuevo libro disponible para reseñar'),
+      })
+    );
+  });
+
+  test('aborts the publication when the cover cannot be downloaded', async () => {
+    renderBookImage.mockRejectedValueOnce(new Error('cover download failed with status 404'));
+    const book = bookDoc({ populate: jest.fn().mockResolvedValue(bookDoc()) });
+
+    await expect(publishToInstagram(book)).resolves.toBeUndefined();
+
+    expect(savePreview).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      '[instagram-autopost]',
+      'error',
+      expect.objectContaining({ bookId: 'b1', message: 'cover download failed with status 404' })
     );
   });
 

--- a/tests/instagram.test.js
+++ b/tests/instagram.test.js
@@ -1,10 +1,19 @@
-jest.mock('../models/book', () => require('./helpers/modelMock').makeModelMock(['findOne']));
+jest.mock('../models/book', () => require('./helpers/modelMock').makeModelMock(['findOne', 'updateOne']));
 jest.mock('../lib/instagram/image', () => ({ renderBookImage: jest.fn().mockResolvedValue(Buffer.from('jpeg')) }));
+jest.mock('../lib/instagram/cloudinary', () => ({ uploadImage: jest.fn().mockResolvedValue('https://res.cloudinary.com/demo/instagram-posts/b1.jpg') }));
+jest.mock('../lib/instagram/graphApi', () => ({
+  createMediaContainer: jest.fn().mockResolvedValue('container-1'),
+  waitForContainer: jest.fn().mockResolvedValue(undefined),
+  publishContainer: jest.fn().mockResolvedValue('media-9'),
+}));
 jest.mock('../lib/instagram/preview', () => ({ savePreview: jest.fn().mockResolvedValue('/tmp/ig-preview-b1.jpg') }));
 
 const { publishToInstagram, buildBookData } = require('../lib/instagram');
 const { renderBookImage } = require('../lib/instagram/image');
 const { savePreview } = require('../lib/instagram/preview');
+const { uploadImage } = require('../lib/instagram/cloudinary');
+const graphApi = require('../lib/instagram/graphApi');
+const Book = require('../models/book');
 
 const bookDoc = (overrides = {}) => ({
   _id: 'b1',
@@ -108,6 +117,84 @@ describe('publishToInstagram', () => {
     process.env.SOCIAL_AUTOPOST_ENABLED = 'true';
     await publishToInstagram(book);
     expect(book.populate).toHaveBeenCalled();
+  });
+});
+
+describe('publishToInstagram in real mode', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.SOCIAL_AUTOPOST_ENABLED = 'true';
+    process.env.IG_DRY_RUN = 'false';
+    process.env.IG_PAGE_ACCESS_TOKEN = 'secret-token';
+    process.env.IG_BUSINESS_ACCOUNT_ID = 'ig-1';
+    Book.updateOne.mockResolvedValue({ acknowledged: true });
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.restoreAllMocks();
+  });
+
+  test('uploads, creates the container, waits, publishes and marks the book', async () => {
+    const book = bookDoc({ populate: jest.fn().mockResolvedValue(bookDoc()) });
+
+    await publishToInstagram(book);
+
+    expect(savePreview).not.toHaveBeenCalled();
+    expect(uploadImage).toHaveBeenCalledWith(expect.any(Buffer), 'b1');
+    expect(graphApi.createMediaContainer).toHaveBeenCalledWith(expect.objectContaining({
+      igUserId: 'ig-1',
+      accessToken: 'secret-token',
+      imageUrl: 'https://res.cloudinary.com/demo/instagram-posts/b1.jpg',
+      caption: expect.stringContaining('El libro'),
+    }));
+    expect(graphApi.waitForContainer).toHaveBeenCalledWith(expect.objectContaining({ containerId: 'container-1' }));
+    expect(graphApi.publishContainer).toHaveBeenCalledWith(expect.objectContaining({ containerId: 'container-1' }));
+    expect(Book.updateOne).toHaveBeenCalledWith({ _id: 'b1' }, { instagramPostedAt: expect.any(Date) });
+    expect(book.instagramPostedAt).toBeInstanceOf(Date);
+  });
+
+  test('does not mark the book when the publish call fails', async () => {
+    graphApi.publishContainer.mockRejectedValueOnce(new Error('Graph API 400: Invalid OAuth token (code 190)'));
+    const book = bookDoc({ populate: jest.fn().mockResolvedValue(bookDoc()) });
+
+    await expect(publishToInstagram(book)).resolves.toBeUndefined();
+
+    expect(Book.updateOne).not.toHaveBeenCalled();
+    expect(book.instagramPostedAt).toBeNull();
+    expect(console.error).toHaveBeenCalledWith(
+      '[instagram-autopost]',
+      'error',
+      expect.objectContaining({ bookId: 'b1', message: expect.stringContaining('code 190') })
+    );
+  });
+
+  test('never logs the access token', async () => {
+    graphApi.createMediaContainer.mockRejectedValueOnce(new Error('boom'));
+    const book = bookDoc({ populate: jest.fn().mockResolvedValue(bookDoc()) });
+
+    await publishToInstagram(book);
+
+    const logged = JSON.stringify(console.log.mock.calls) + JSON.stringify(console.error.mock.calls);
+    expect(logged).not.toContain('secret-token');
+  });
+
+  test('aborts when the Instagram credentials are missing', async () => {
+    delete process.env.IG_PAGE_ACCESS_TOKEN;
+    const book = bookDoc({ populate: jest.fn().mockResolvedValue(bookDoc()) });
+
+    await publishToInstagram(book);
+
+    expect(uploadImage).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      '[instagram-autopost]',
+      'error',
+      expect.objectContaining({ message: expect.stringContaining('missing IG_PAGE_ACCESS_TOKEN') })
+    );
   });
 });
 

--- a/tests/instagram.test.js
+++ b/tests/instagram.test.js
@@ -1,0 +1,96 @@
+jest.mock('../models/book', () => require('./helpers/modelMock').makeModelMock(['findOne']));
+
+const { publishToInstagram, buildBookData } = require('../lib/instagram');
+
+const bookDoc = (overrides = {}) => ({
+  _id: 'b1',
+  title: 'El libro',
+  genre: 'ROM',
+  synopsis: 'Una sinopsis',
+  cover: 'https://res.cloudinary.com/demo/image/upload/cover.jpg',
+  formats: ['papel', 'epub'],
+  author: { name: 'Ana', lastName: 'García' },
+  instagramPostedAt: null,
+  ...overrides,
+});
+
+describe('publishToInstagram', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.SOCIAL_AUTOPOST_ENABLED = 'true';
+    process.env.IG_DRY_RUN = 'true';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.restoreAllMocks();
+  });
+
+  test('does nothing when the feature flag is off', async () => {
+    process.env.SOCIAL_AUTOPOST_ENABLED = 'false';
+    const book = bookDoc({ populate: jest.fn() });
+
+    await publishToInstagram(book);
+
+    expect(book.populate).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when the book was already posted', async () => {
+    const book = bookDoc({ instagramPostedAt: new Date(), populate: jest.fn() });
+
+    await publishToInstagram(book);
+
+    expect(book.populate).not.toHaveBeenCalled();
+  });
+
+  test('swallows and logs any error instead of rejecting', async () => {
+    const book = bookDoc({ populate: jest.fn().mockRejectedValue(new Error('boom')) });
+
+    await expect(publishToInstagram(book)).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith(
+      '[instagram-autopost]',
+      'error',
+      expect.objectContaining({ step: 'publish', bookId: 'b1', message: 'boom' })
+    );
+  });
+
+  test('flag reads process.env at call time, not at import time', async () => {
+    const book = bookDoc({ populate: jest.fn().mockResolvedValue(bookDoc()) });
+
+    process.env.SOCIAL_AUTOPOST_ENABLED = 'false';
+    await publishToInstagram(book);
+    expect(book.populate).not.toHaveBeenCalled();
+
+    process.env.SOCIAL_AUTOPOST_ENABLED = 'true';
+    await publishToInstagram(book);
+    expect(book.populate).toHaveBeenCalled();
+  });
+});
+
+describe('buildBookData', () => {
+  test('flattens the document and joins the author display name', async () => {
+    const populated = bookDoc();
+    const data = await buildBookData(bookDoc({ populate: jest.fn().mockResolvedValue(populated) }));
+
+    expect(data).toEqual({
+      id: 'b1',
+      title: 'El libro',
+      author: 'Ana García',
+      genre: 'ROM',
+      synopsis: 'Una sinopsis',
+      cover: 'https://res.cloudinary.com/demo/image/upload/cover.jpg',
+      formats: ['papel', 'epub'],
+    });
+  });
+
+  test('leaves the author null when it could not be populated', async () => {
+    const populated = bookDoc({ author: 'u1' });
+    const data = await buildBookData(bookDoc({ author: 'u1', populate: jest.fn().mockResolvedValue(populated) }));
+
+    expect(data.author).toBeNull();
+  });
+});

--- a/tests/instagramCaption.test.js
+++ b/tests/instagramCaption.test.js
@@ -1,0 +1,74 @@
+const { buildCaption, joinFormats, synopsisExcerpt } = require('../lib/instagram/caption');
+
+describe('joinFormats', () => {
+  test('returns a single format as is', () => {
+    expect(joinFormats(['papel'])).toBe('papel');
+  });
+
+  test('joins two formats with "y"', () => {
+    expect(joinFormats(['papel', 'epub'])).toBe('papel y ePub');
+  });
+
+  test('joins three or more with commas and a final "y"', () => {
+    expect(joinFormats(['papel', 'epub', 'pdf'])).toBe('papel, ePub y PDF');
+  });
+
+  test('returns an empty string when there are no formats', () => {
+    expect(joinFormats([])).toBe('');
+  });
+});
+
+describe('synopsisExcerpt', () => {
+  test('keeps a short synopsis untouched', () => {
+    expect(synopsisExcerpt('Una sinopsis corta.')).toBe('Una sinopsis corta.');
+  });
+
+  test('cuts on a word boundary under the 200 character limit', () => {
+    const synopsis = `${'palabra '.repeat(40)}final`;
+    const excerpt = synopsisExcerpt(synopsis);
+
+    expect(excerpt.length).toBeLessThanOrEqual(200);
+    expect(excerpt.endsWith('palabra')).toBe(true);
+    expect(synopsis.startsWith(excerpt)).toBe(true);
+  });
+
+  test('collapses whitespace and line breaks', () => {
+    expect(synopsisExcerpt('Una   sinopsis\n con saltos')).toBe('Una sinopsis con saltos');
+  });
+});
+
+describe('buildCaption', () => {
+  const book = {
+    title: 'El nombre del viento',
+    author: 'Patrick Rothfuss',
+    formats: ['papel', 'epub'],
+    synopsis: 'He robado princesas a reyes agónicos.',
+  };
+
+  test('follows the approved template', () => {
+    expect(buildCaption(book)).toBe(
+      '📚 Nuevo libro disponible para reseñar: El nombre del viento, de Patrick Rothfuss.\n\n' +
+      'Disponible en papel y ePub.\n\n' +
+      'He robado princesas a reyes agónicos.\n\n' +
+      'Pide tu ejemplar gratuito desde el enlace en nuestra bio.'
+    );
+  });
+
+  test('adds the ellipsis only when the synopsis was truncated', () => {
+    const long = buildCaption({ ...book, synopsis: 'palabra '.repeat(60) });
+
+    expect(long).toContain('…');
+    expect(buildCaption(book)).not.toContain('…');
+  });
+
+  test('never adds hashtags', () => {
+    expect(buildCaption(book)).not.toContain('#');
+  });
+
+  test('omits the author and the formats line when they are missing', () => {
+    const caption = buildCaption({ ...book, author: null, formats: [] });
+
+    expect(caption).toContain('reseñar: El nombre del viento.');
+    expect(caption).not.toContain('Disponible en');
+  });
+});

--- a/tests/instagramGraphApi.test.js
+++ b/tests/instagramGraphApi.test.js
@@ -1,0 +1,74 @@
+const { createMediaContainer, waitForContainer, publishContainer } = require('../lib/instagram/graphApi');
+
+const json = (body, ok = true, status = 200) => ({ ok, status, json: async () => body });
+
+describe('graph API client', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    jest.restoreAllMocks();
+  });
+
+  test('creates the media container and returns its id', async () => {
+    global.fetch.mockResolvedValue(json({ id: 'container-1' }));
+
+    const id = await createMediaContainer({
+      igUserId: 'ig-1', accessToken: 'secret', imageUrl: 'https://cdn/x.jpg', caption: 'hola',
+    });
+
+    expect(id).toBe('container-1');
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe('https://graph.facebook.com/v26.0/ig-1/media');
+    expect(options.method).toBe('POST');
+    expect(options.body.get('image_url')).toBe('https://cdn/x.jpg');
+    expect(options.body.get('caption')).toBe('hola');
+  });
+
+  test('surfaces the Meta error message and code', async () => {
+    global.fetch.mockResolvedValue(json({ error: { message: 'Invalid OAuth token', code: 190 } }, false, 400));
+
+    await expect(createMediaContainer({ igUserId: 'ig-1', accessToken: 'secret' }))
+      .rejects.toThrow('Graph API 400: Invalid OAuth token (code 190)');
+  });
+
+  test('polls until the container is FINISHED', async () => {
+    global.fetch
+      .mockResolvedValueOnce(json({ status_code: 'IN_PROGRESS' }))
+      .mockResolvedValueOnce(json({ status_code: 'FINISHED' }));
+
+    await waitForContainer({ containerId: 'c1', accessToken: 'secret', delayMs: 0 });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('gives up instead of publishing a container that never finished', async () => {
+    global.fetch.mockResolvedValue(json({ status_code: 'IN_PROGRESS' }));
+
+    await expect(waitForContainer({ containerId: 'c1', accessToken: 'secret', attempts: 3, delayMs: 0 }))
+      .rejects.toThrow('container c1 was not FINISHED after 3 attempts');
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('aborts as soon as the container reports ERROR', async () => {
+    global.fetch.mockResolvedValue(json({ status_code: 'ERROR' }));
+
+    await expect(waitForContainer({ containerId: 'c1', accessToken: 'secret', delayMs: 0 }))
+      .rejects.toThrow('container c1 ended in status ERROR');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('publishes the container and returns the media id', async () => {
+    global.fetch.mockResolvedValue(json({ id: 'media-9' }));
+
+    const id = await publishContainer({ igUserId: 'ig-1', accessToken: 'secret', containerId: 'c1' });
+
+    expect(id).toBe('media-9');
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe('https://graph.facebook.com/v26.0/ig-1/media_publish');
+    expect(options.body.get('creation_id')).toBe('c1');
+  });
+});

--- a/tests/instagramImage.test.js
+++ b/tests/instagramImage.test.js
@@ -1,0 +1,54 @@
+const { createCanvas } = require('@napi-rs/canvas');
+const { renderBookImage, wrapText, WIDTH, HEIGHT } = require('../lib/instagram/image');
+
+const book = {
+  id: 'b1',
+  title: 'El nombre del viento',
+  author: 'Patrick Rothfuss',
+  genre: 'FAN',
+  cover: 'https://res.cloudinary.com/demo/image/upload/cover.jpg',
+  formats: ['papel', 'epub'],
+};
+
+const jpegResponse = async () => {
+  const canvas = createCanvas(60, 80);
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#123456';
+  ctx.fillRect(0, 0, 60, 80);
+  const buffer = await canvas.encode('jpeg', 80);
+  return { ok: true, status: 200, arrayBuffer: async () => buffer };
+};
+
+describe('wrapText', () => {
+  test('breaks by words, never mid-word', () => {
+    const ctx = createCanvas(WIDTH, HEIGHT).getContext('2d');
+    ctx.font = '600 56px Georgia';
+
+    const lines = wrapText(ctx, 'una frase bastante larga que no cabe entera en una sola linea del lienzo', 400);
+
+    expect(lines.length).toBeGreaterThan(1);
+    lines.forEach((line) => expect(ctx.measureText(line).width).toBeLessThanOrEqual(400));
+    expect(lines.join(' ')).toBe('una frase bastante larga que no cabe entera en una sola linea del lienzo');
+  });
+});
+
+describe('renderBookImage', () => {
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('returns a JPEG buffer of the Instagram feed size', async () => {
+    global.fetch = jest.fn(jpegResponse);
+
+    const buffer = await renderBookImage(book);
+
+    expect(buffer.slice(0, 2)).toEqual(Buffer.from([0xff, 0xd8])); // JPEG magic number
+    expect(global.fetch).toHaveBeenCalledWith(book.cover, expect.any(Object));
+  });
+
+  test('rejects when the cover cannot be downloaded, so nothing gets published', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(renderBookImage(book)).rejects.toThrow(/cover download failed with status 404/);
+  });
+});

--- a/tests/registerBook.test.js
+++ b/tests/registerBook.test.js
@@ -6,10 +6,17 @@ jest.mock('stripe', () => jest.fn(() => ({ paymentIntents: { create: jest.fn() }
 jest.mock('../models/user', () => require('./helpers/modelMock').makeModelMock(['findOne']));
 jest.mock('../models/book', () => require('./helpers/modelMock').makeModelMock(['findOne', 'updateOne']));
 jest.mock('../models/reviewer', () => require('./helpers/modelMock').makeModelMock(['findOne']));
+jest.mock('../lib/email', () => ({
+  transporter: { sendMail: jest.fn((template, cb) => cb(null)) },
+  newBookTemplate: jest.fn(() => ({})),
+}));
+jest.mock('../lib/instagram', () => ({ publishToInstagram: jest.fn().mockResolvedValue(undefined) }));
 
 const request = require('supertest');
 const jwt = require('jsonwebtoken');
 const Book = require('../models/book');
+const User = require('../models/user');
+const { publishToInstagram } = require('../lib/instagram');
 const app = require('../app');
 
 const tokenFor = (user) => jwt.sign({ user }, process.env.JWT_SECRET);
@@ -36,6 +43,26 @@ describe('registerBook routes', () => {
 
     expect(res.body.message).toMatch(/no tienes autorización/);
     expect(Book.updateOne).not.toHaveBeenCalled();
+  });
+
+  test('POST /registerBook triggers the Instagram autopost with the saved book', async () => {
+    Book.findOne.mockResolvedValue(null);
+    User.findOne.mockResolvedValue({ email: 'a@b.com', name: 'Ana' });
+
+    const res = await request(app).post('/registerBook').send({ title: 'Nuevo', author: 'u1' });
+
+    expect(res.body.success).toBe(true);
+    expect(publishToInstagram).toHaveBeenCalledWith(expect.objectContaining({ title: 'Nuevo' }));
+  });
+
+  test('POST /registerBook still succeeds when the Instagram autopost fails', async () => {
+    Book.findOne.mockResolvedValue(null);
+    User.findOne.mockResolvedValue({ email: 'a@b.com', name: 'Ana' });
+    publishToInstagram.mockRejectedValueOnce(new Error('instagram down'));
+
+    const res = await request(app).post('/registerBook').send({ title: 'Otro', author: 'u1' });
+
+    expect(res.body.success).toBe(true);
   });
 
   test('PUT /registerBook/:id requires a token', async () => {


### PR DESCRIPTION
Implementa `docs/instagram-autopost-spec.md`: al crear un libro se publica automáticamente en Instagram una imagen de marca 1080x1350 con la portada, el título, el autor, el género y los formatos, más un caption en español con un extracto de la sinopsis.

## Cómo está montado

- `lib/instagram/` — `config` (env leída en runtime, nunca en el arranque), `caption`, `image` (compositing con `@napi-rs/canvas`), `preview` (dry-run), `cloudinary` (subida a `instagram-posts/`), `graphApi` (v26.0: contenedor → polling hasta `FINISHED` → publish) y `index` (orquestador).
- `routes/registerBook.js` dispara `publishToInstagram(newBook)` **sin await**: la respuesta al cliente no se retrasa ni se rompe pase lo que pase.
- `models/book.js` gana `instagramPostedAt`, que solo se setea tras una publicación real (nunca en dry-run), evitando duplicados.

## Verificación

- `SOCIAL_AUTOPOST_ENABLED=false` desactiva la feature sin tocar código.
- `IG_DRY_RUN=true` (por defecto) genera la imagen y el caption, guarda el `.jpg` en `tmp/` y no llama ni a Cloudinary ni a Meta. Probado en local.
- Si falla la descarga de la portada o cualquier llamada a la Graph API, se aborta la publicación, se loguea con `bookId` y paso, y el alta del libro responde con éxito igualmente.
- El token nunca se loguea (hay un test que lo comprueba).
- 82 tests en verde y lint limpio.

## Antes de poner `IG_DRY_RUN=false`

Faltan por crear en Heroku las config vars `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY` y `CLOUDINARY_API_SECRET` (la Graph API exige una URL pública, no acepta un buffer).

Nota: las fuentes de marca no están empaquetadas; se usan caras genéricas del sistema. Al dejar los `.ttf` en `assets/fonts/` se registran solas.

Versión: 3.5.0 → 3.6.0 (MINOR: integración nueva + campo nuevo en el modelo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jcPcNwEfX6zThwmJiK8YT